### PR TITLE
Feature/device groups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,6 @@ WEB3=http://localhost:8545
 DEBUG_API_KEY=debug
 
 BACKEND_PORT=3040
-JWT_SECRET=thisisnotsecret
-JWT_EXPIRY_TIME="7 days"
 
 # --- DATABASE --- #
 DB_HOST=localhost

--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,10 @@ WEB3=http://localhost:8545
 
 DEBUG_API_KEY=debug
 
+BACKEND_PORT=3040
+JWT_SECRET=thisisnotsecret
+JWT_EXPIRY_TIME="7 days"
+
 # --- DATABASE --- #
 DB_HOST=localhost
 DB_PORT=5432

--- a/apps/drec-api/migrations/1627394014670-DeviceGroup.ts
+++ b/apps/drec-api/migrations/1627394014670-DeviceGroup.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class DeviceGroup1627394014670 implements MigrationInterface {
+  name = 'DeviceGroup1627394014670';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "device_group" ("createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "id" SERIAL NOT NULL, "name" character varying NOT NULL, "organizationId" character varying NOT NULL, CONSTRAINT "UQ_f2ef78d341a5125990cafc9493c" UNIQUE ("name"), CONSTRAINT "PK_6bb808be579ff0722c914a8d6a1" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(`ALTER TABLE "device" ADD "groupId" integer`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "device" DROP COLUMN "groupId"`);
+    await queryRunner.query(`DROP TABLE "device_group"`);
+  }
+}

--- a/apps/drec-api/src/drec.module.ts
+++ b/apps/drec-api/src/drec.module.ts
@@ -15,6 +15,8 @@ import { Device } from './pods/device/device.entity';
 import { DeviceModule } from './pods/device/device.module';
 import { File, FileModule } from './pods/file';
 import { ReadsModule } from './pods/reads/reads.module';
+import { DeviceGroup } from './pods/device-group/device-group.entity';
+import { DeviceGroupModule } from './pods/device-group/device-group.module';
 
 const getEnvFilePath = () => {
   const pathsToTest = [
@@ -39,6 +41,7 @@ export const entities = [
   User,
   Organization,
   Device,
+  DeviceGroup,
   File,
   Certificate,
   BlockchainProperties,
@@ -79,6 +82,7 @@ const OriginAppTypeOrmModule = () => {
     UserModule,
     OrganizationModule,
     DeviceModule,
+    DeviceGroupModule,
     FileModule,
     ReadsModule,
   ],

--- a/apps/drec-api/src/pods/device-group/device-group.controller.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.controller.ts
@@ -20,7 +20,12 @@ import {
 import { AuthGuard } from '@nestjs/passport';
 
 import { DeviceGroupService } from './device-group.service';
-import { DeviceGroupDTO, NewDeviceGroupDTO, UpdateDeviceGroupDTO } from './dto';
+import {
+  DeviceGroupDTO,
+  DeviceIdsDTO,
+  NewDeviceGroupDTO,
+  UpdateDeviceGroupDTO,
+} from './dto';
 import { Roles } from '../user/decorators/roles.decorator';
 import { Role } from '../../utils/eums';
 import { RolesGuard } from '../../auth/roles-guard';
@@ -72,6 +77,36 @@ export class DeviceGroupController {
       user.organization.code,
       deviceGroupToRegister,
     );
+  }
+
+  @Post('/add/:id')
+  @UseGuards(RolesGuard)
+  @Roles(Role.Buyer, Role.Admin)
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: DeviceGroupDTO,
+    description: 'Returns a new created Device group',
+  })
+  public async addDevices(
+    @Param('id') id: number,
+    @Body() deviceIds: DeviceIdsDTO,
+  ) {
+    return await this.deviceGroupService.addDevices(id, deviceIds);
+  }
+
+  @Post('/remove/:id')
+  @UseGuards(RolesGuard)
+  @Roles(Role.Buyer, Role.Admin)
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: DeviceGroupDTO,
+    description: 'Returns a new created Device group',
+  })
+  public async removeDevices(
+    @Param('id') id: number,
+    @Body() deviceIds: DeviceIdsDTO,
+  ) {
+    return await this.deviceGroupService.removeDevices(id, deviceIds);
   }
 
   @Patch('/:id')

--- a/apps/drec-api/src/pods/device-group/device-group.controller.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.controller.ts
@@ -54,11 +54,12 @@ export class DeviceGroupController {
     type: DeviceGroupDTO,
     description: 'Returns a Device group',
   })
-  @ApiNotFoundResponse({
-    description: `The device with the id doesn't exist`,
-  })
-  async get(@Param('id') id: number): Promise<DeviceGroupDTO | null> {
-    return this.deviceGroupService.findById(id);
+  @ApiNotFoundResponse({ description: `No device group found` })
+  async get(
+    @Param('id') id: number,
+    @UserDecorator() user: OrganizationUserDTO,
+  ): Promise<DeviceGroupDTO | null> {
+    return this.deviceGroupService.findById(id, user.organization.code);
   }
 
   @Post()
@@ -89,9 +90,14 @@ export class DeviceGroupController {
   })
   public async addDevices(
     @Param('id') id: number,
+    @UserDecorator() user: OrganizationUserDTO,
     @Body() deviceIds: DeviceIdsDTO,
   ) {
-    return await this.deviceGroupService.addDevices(id, deviceIds);
+    return await this.deviceGroupService.addDevices(
+      id,
+      user.organization.code,
+      deviceIds,
+    );
   }
 
   @Post('/remove/:id')
@@ -104,9 +110,14 @@ export class DeviceGroupController {
   })
   public async removeDevices(
     @Param('id') id: number,
+    @UserDecorator() user: OrganizationUserDTO,
     @Body() deviceIds: DeviceIdsDTO,
   ) {
-    return await this.deviceGroupService.removeDevices(id, deviceIds);
+    return await this.deviceGroupService.removeDevices(
+      id,
+      user.organization.code,
+      deviceIds,
+    );
   }
 
   @Patch('/:id')
@@ -117,12 +128,17 @@ export class DeviceGroupController {
     type: UpdateDeviceGroupDTO,
     description: 'Returns an updated Device Group',
   })
-  @ApiNotFoundResponse({ description: `No device found` })
+  @ApiNotFoundResponse({ description: `No device group found` })
   public async update(
     @Param('id') id: number,
+    @UserDecorator() user: OrganizationUserDTO,
     @Body() groupToUpdate: UpdateDeviceGroupDTO,
   ) {
-    return await this.deviceGroupService.update(id, groupToUpdate);
+    return await this.deviceGroupService.update(
+      id,
+      user.organization.code,
+      groupToUpdate,
+    );
   }
 
   @Delete('/:id')
@@ -132,7 +148,11 @@ export class DeviceGroupController {
     status: HttpStatus.OK,
     description: 'Remove device group',
   })
-  public async remove(@Param('id') id: number): Promise<void> {
-    return await this.deviceGroupService.remove(id);
+  @ApiNotFoundResponse({ description: `No device group found` })
+  public async remove(
+    @Param('id') id: number,
+    @UserDecorator() user: OrganizationUserDTO,
+  ): Promise<void> {
+    return await this.deviceGroupService.remove(id, user.organization.code);
   }
 }

--- a/apps/drec-api/src/pods/device-group/device-group.controller.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.controller.ts
@@ -1,0 +1,103 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  HttpStatus,
+  Param,
+  Body,
+  UseGuards,
+  Delete,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiNotFoundResponse,
+  ApiResponse,
+  ApiOkResponse,
+  ApiSecurity,
+  ApiTags,
+} from '@nestjs/swagger';
+import { AuthGuard } from '@nestjs/passport';
+
+import { DeviceGroupService } from './device-group.service';
+import { DeviceGroupDTO, NewDeviceGroupDTO, UpdateDeviceGroupDTO } from './dto';
+import { Roles } from '../user/decorators/roles.decorator';
+import { Role } from '../../utils/eums';
+import { RolesGuard } from '../../auth/roles-guard';
+import { UserDecorator } from '../user/decorators/user.decorator';
+import { OrganizationUserDTO } from '../../auth/dto/org-user.dto';
+
+@ApiTags('device-group')
+@ApiBearerAuth('access-token')
+@ApiSecurity('drec')
+@Controller('/device-group')
+@UseGuards(AuthGuard('jwt'))
+export class DeviceGroupController {
+  constructor(private readonly deviceGroupService: DeviceGroupService) {}
+
+  @Get()
+  @ApiOkResponse({
+    type: [DeviceGroupDTO],
+    description: 'Returns all Device groups',
+  })
+  async getAll(): Promise<DeviceGroupDTO[]> {
+    return this.deviceGroupService.getAll();
+  }
+
+  @Get('/:id')
+  @ApiOkResponse({
+    type: DeviceGroupDTO,
+    description: 'Returns a Device group',
+  })
+  @ApiNotFoundResponse({
+    description: `The device with the id doesn't exist`,
+  })
+  async get(@Param('id') id: number): Promise<DeviceGroupDTO | null> {
+    return this.deviceGroupService.findById(id);
+  }
+
+  @Post()
+  @UseGuards(RolesGuard)
+  @Roles(Role.Buyer, Role.Admin)
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: DeviceGroupDTO,
+    description: 'Returns a new created Device group',
+  })
+  public async create(
+    @UserDecorator() user: OrganizationUserDTO,
+    @Body() deviceGroupToRegister: NewDeviceGroupDTO,
+  ) {
+    return await this.deviceGroupService.create(
+      user.organization.code,
+      deviceGroupToRegister,
+    );
+  }
+
+  @Patch('/:id')
+  @UseGuards(RolesGuard)
+  @Roles(Role.Buyer, Role.Admin)
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: UpdateDeviceGroupDTO,
+    description: 'Returns an updated Device Group',
+  })
+  @ApiNotFoundResponse({ description: `No device found` })
+  public async update(
+    @Param('id') id: number,
+    @Body() groupToUpdate: UpdateDeviceGroupDTO,
+  ) {
+    return await this.deviceGroupService.update(id, groupToUpdate);
+  }
+
+  @Delete('/:id')
+  @UseGuards(RolesGuard)
+  @Roles(Role.Buyer, Role.Admin)
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Remove device group',
+  })
+  public async remove(@Param('id') id: number): Promise<void> {
+    return await this.deviceGroupService.remove(id);
+  }
+}

--- a/apps/drec-api/src/pods/device-group/device-group.entity.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.entity.ts
@@ -1,0 +1,27 @@
+import { ExtendedBaseEntity } from '@energyweb/origin-backend-utils';
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { IsString, IsNotEmpty } from 'class-validator';
+import { IDevice } from '../device';
+
+export interface IDeviceGroup {
+  id: number;
+  name: string;
+  organizationId: string;
+  devices?: IDevice[];
+}
+
+@Entity()
+export class DeviceGroup extends ExtendedBaseEntity implements IDeviceGroup {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ unique: true })
+  @IsNotEmpty()
+  @IsString()
+  name: string;
+
+  @Column()
+  organizationId: string;
+
+  devices?: IDevice[];
+}

--- a/apps/drec-api/src/pods/device-group/device-group.module.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DeviceModule } from '../device/device.module';
+import { DeviceGroupController } from './device-group.controller';
+import { DeviceGroup } from './device-group.entity';
+import { DeviceGroupService } from './device-group.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([DeviceGroup]), DeviceModule],
+  providers: [DeviceGroupService],
+  exports: [DeviceGroupService],
+  controllers: [DeviceGroupController],
+})
+export class DeviceGroupModule {}

--- a/apps/drec-api/src/pods/device-group/device-group.service.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.service.ts
@@ -1,0 +1,118 @@
+import {
+  Injectable,
+  NotFoundException,
+  Logger,
+  ConflictException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { FindOneOptions, Repository, FindConditions } from 'typeorm';
+import { DeviceService } from '../device/device.service';
+import { NewDeviceGroupDTO, UpdateDeviceGroupDTO } from './dto';
+import { DeviceGroup } from './device-group.entity';
+import { Device } from '../device/device.entity';
+
+@Injectable()
+export class DeviceGroupService {
+  private readonly logger = new Logger(DeviceGroupService.name);
+
+  constructor(
+    @InjectRepository(DeviceGroup)
+    private readonly repository: Repository<DeviceGroup>,
+    private deviceService: DeviceService,
+  ) {}
+
+  async getAll(): Promise<DeviceGroup[]> {
+    return this.repository.find();
+  }
+
+  async findById(
+    id: number,
+    options: FindOneOptions<DeviceGroup> = {},
+  ): Promise<DeviceGroup> {
+    const deviceGroup = await this.repository.findOne(id, {
+      ...options,
+    });
+    if (!deviceGroup) {
+      throw new NotFoundException(`No device group found with id ${id}`);
+    }
+    deviceGroup.devices = await this.deviceService.findForGroup(deviceGroup.id);
+    return deviceGroup;
+  }
+
+  async findOne(
+    conditions: FindConditions<DeviceGroup>,
+  ): Promise<DeviceGroup | null> {
+    return (await this.repository.findOne(conditions)) ?? null;
+  }
+
+  async create(
+    organizationId: string,
+    data: NewDeviceGroupDTO,
+  ): Promise<DeviceGroup> {
+    await this.checkNameConflict(data.name);
+
+    const group = await this.repository.save({
+      name: data.name,
+      organizationId,
+    });
+
+    // For each device id, add the groupId but make sure they all belong to the same owner
+    const devices = await this.deviceService.findByIds(data.deviceIds);
+    const ownerCode = devices[0].registrant_organisation_code;
+    await Promise.all(
+      devices.map(async (device: Device) => {
+        await this.deviceService.addToGroup(device, group.id, ownerCode);
+      }),
+    );
+
+    return group;
+  }
+
+  async update(id: number, data: UpdateDeviceGroupDTO): Promise<DeviceGroup> {
+    await this.checkNameConflict(data.name);
+    const deviceGroup = await this.repository.findOne(id);
+    if (!deviceGroup) {
+      throw new NotFoundException(`No device group found with id ${id}`);
+    }
+    deviceGroup.name = data.name;
+    const updatedGroup = await this.repository.save(deviceGroup);
+    updatedGroup.devices = await this.deviceService.findForGroup(
+      deviceGroup.id,
+    );
+    return updatedGroup;
+  }
+
+  async remove(id: number): Promise<void> {
+    const deviceGroup = await this.repository.findOne(id);
+    if (!deviceGroup) {
+      throw new NotFoundException(`No device group found with id ${id}`);
+    }
+    const devices = await this.deviceService.findForGroup(deviceGroup.id);
+    await Promise.all(
+      devices.map(async (device: Device) => {
+        return await this.deviceService.removeFromGroup(
+          device.id,
+          deviceGroup.id,
+        );
+      }),
+    );
+    await this.repository.delete(id);
+  }
+
+  private async hasDeviceGroup(conditions: FindConditions<DeviceGroup>) {
+    return Boolean(await this.findOne(conditions));
+  }
+
+  private async checkNameConflict(name: string): Promise<void> {
+    const isExistingDeviceGroup = await this.hasDeviceGroup({ name: name });
+    if (isExistingDeviceGroup) {
+      const message = `Device group with name ${name} already exists`;
+
+      this.logger.error(message);
+      throw new ConflictException({
+        success: false,
+        message,
+      });
+    }
+  }
+}

--- a/apps/drec-api/src/pods/device-group/device-group.service.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.service.ts
@@ -67,6 +67,10 @@ export class DeviceGroupService {
       ?.registrant_organisation_code;
     const devices = await this.deviceService.findByIds(data.deviceIds);
 
+    if (!data?.deviceIds?.length) {
+      return;
+    }
+
     await Promise.all(
       devices.map(async (device: Device) => {
         await this.deviceService.addToGroup(device, id, ownerCode);
@@ -79,11 +83,16 @@ export class DeviceGroupService {
   async removeDevices(id: number, data: DeviceIdsDTO): Promise<DeviceGroup> {
     const deviceGroup = await this.findDeviceGroupById(id);
 
+    if (!data?.deviceIds?.length) {
+      return;
+    }
+
     await Promise.all(
       data.deviceIds.map(async (deviceId: number) => {
         await this.deviceService.removeFromGroup(deviceId, id);
       }),
     );
+
     deviceGroup.devices = await this.deviceService.findForGroup(deviceGroup.id);
     return deviceGroup;
   }

--- a/apps/drec-api/src/pods/device-group/device-group.service.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.service.ts
@@ -25,8 +25,8 @@ export class DeviceGroupService {
     return this.repository.find();
   }
 
-  async findById(id: number): Promise<DeviceGroup> {
-    const deviceGroup = await this.findDeviceGroupById(id);
+  async findById(id: number, organizationId: string): Promise<DeviceGroup> {
+    const deviceGroup = await this.findDeviceGroupById(id, organizationId);
     deviceGroup.devices = await this.deviceService.findForGroup(deviceGroup.id);
     return deviceGroup;
   }
@@ -60,8 +60,12 @@ export class DeviceGroupService {
     return group;
   }
 
-  async addDevices(id: number, data: DeviceIdsDTO): Promise<DeviceGroup> {
-    const deviceGroup = await this.findDeviceGroupById(id);
+  async addDevices(
+    id: number,
+    organizationId: string,
+    data: DeviceIdsDTO,
+  ): Promise<DeviceGroup> {
+    const deviceGroup = await this.findDeviceGroupById(id, organizationId);
 
     const ownerCode = ((await this.deviceService.findForGroup(id)[0]) as Device)
       ?.registrant_organisation_code;
@@ -80,8 +84,12 @@ export class DeviceGroupService {
     return deviceGroup;
   }
 
-  async removeDevices(id: number, data: DeviceIdsDTO): Promise<DeviceGroup> {
-    const deviceGroup = await this.findDeviceGroupById(id);
+  async removeDevices(
+    id: number,
+    organizationId: string,
+    data: DeviceIdsDTO,
+  ): Promise<DeviceGroup> {
+    const deviceGroup = await this.findDeviceGroupById(id, organizationId);
 
     if (!data?.deviceIds?.length) {
       return;
@@ -97,9 +105,13 @@ export class DeviceGroupService {
     return deviceGroup;
   }
 
-  async update(id: number, data: UpdateDeviceGroupDTO): Promise<DeviceGroup> {
+  async update(
+    id: number,
+    organizationId: string,
+    data: UpdateDeviceGroupDTO,
+  ): Promise<DeviceGroup> {
     await this.checkNameConflict(data.name);
-    const deviceGroup = await this.findDeviceGroupById(id);
+    const deviceGroup = await this.findDeviceGroupById(id, organizationId);
 
     deviceGroup.name = data.name;
     const updatedGroup = await this.repository.save(deviceGroup);
@@ -109,8 +121,8 @@ export class DeviceGroupService {
     return updatedGroup;
   }
 
-  async remove(id: number): Promise<void> {
-    const deviceGroup = await this.findDeviceGroupById(id);
+  async remove(id: number, organizationId: string): Promise<void> {
+    const deviceGroup = await this.findDeviceGroupById(id, organizationId);
 
     const devices = await this.deviceService.findForGroup(deviceGroup.id);
     await Promise.all(
@@ -141,10 +153,18 @@ export class DeviceGroupService {
     }
   }
 
-  private async findDeviceGroupById(id: number): Promise<DeviceGroup> {
-    const deviceGroup = await this.repository.findOne(id);
+  private async findDeviceGroupById(
+    id: number,
+    organizationId,
+  ): Promise<DeviceGroup> {
+    const deviceGroup = await this.repository.findOne({
+      id,
+      organizationId,
+    });
     if (!deviceGroup) {
-      throw new NotFoundException(`No device group found with id ${id}`);
+      throw new NotFoundException(
+        `No device group found with id ${id} and organization ${organizationId}`,
+      );
     }
     return deviceGroup;
   }

--- a/apps/drec-api/src/pods/device-group/device-group.service.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.service.ts
@@ -5,7 +5,7 @@ import {
   ConflictException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { FindOneOptions, Repository, FindConditions } from 'typeorm';
+import { Repository, FindConditions } from 'typeorm';
 import { DeviceService } from '../device/device.service';
 import { DeviceIdsDTO, NewDeviceGroupDTO, UpdateDeviceGroupDTO } from './dto';
 import { DeviceGroup } from './device-group.entity';

--- a/apps/drec-api/src/pods/device-group/dto/device-group.dto.ts
+++ b/apps/drec-api/src/pods/device-group/dto/device-group.dto.ts
@@ -1,0 +1,17 @@
+import { IsString, IsNumber } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { IDeviceGroup } from '../device-group.entity';
+
+export class DeviceGroupDTO implements IDeviceGroup {
+  @ApiProperty()
+  @IsNumber()
+  id: number;
+
+  @ApiProperty()
+  @IsString()
+  name: string;
+
+  @ApiProperty()
+  @IsString()
+  organizationId: string;
+}

--- a/apps/drec-api/src/pods/device-group/dto/device-id.dto.ts
+++ b/apps/drec-api/src/pods/device-group/dto/device-id.dto.ts
@@ -1,0 +1,8 @@
+import { IsNumber } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DeviceIdDTO {
+  @ApiProperty()
+  @IsNumber()
+  id: number;
+}

--- a/apps/drec-api/src/pods/device-group/dto/device-ids.dto.ts
+++ b/apps/drec-api/src/pods/device-group/dto/device-ids.dto.ts
@@ -1,0 +1,8 @@
+import { IsArray } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DeviceIdsDTO {
+  @ApiProperty()
+  @IsArray()
+  deviceIds: number[];
+}

--- a/apps/drec-api/src/pods/device-group/dto/device-ids.dto.ts
+++ b/apps/drec-api/src/pods/device-group/dto/device-ids.dto.ts
@@ -1,8 +1,9 @@
-import { IsArray } from 'class-validator';
+import { IsInt, Min } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class DeviceIdsDTO {
-  @ApiProperty()
-  @IsArray()
+  @ApiProperty({ type: [Number] })
+  @IsInt({ each: true })
+  @Min(1, { each: true })
   deviceIds: number[];
 }

--- a/apps/drec-api/src/pods/device-group/dto/index.ts
+++ b/apps/drec-api/src/pods/device-group/dto/index.ts
@@ -1,0 +1,5 @@
+export * from './new-device-group.dto';
+export * from './device-group.dto';
+export * from './device-ids.dto';
+export * from './device-id.dto';
+export * from './update-device.dto';

--- a/apps/drec-api/src/pods/device-group/dto/new-device-group.dto.ts
+++ b/apps/drec-api/src/pods/device-group/dto/new-device-group.dto.ts
@@ -1,0 +1,12 @@
+import { IsString, IsArray } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class NewDeviceGroupDTO {
+  @ApiProperty()
+  @IsString()
+  name: string;
+
+  @ApiProperty()
+  @IsArray()
+  deviceIds: number[];
+}

--- a/apps/drec-api/src/pods/device-group/dto/new-device-group.dto.ts
+++ b/apps/drec-api/src/pods/device-group/dto/new-device-group.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsArray } from 'class-validator';
+import { IsString, IsArray, IsNumber } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class NewDeviceGroupDTO {

--- a/apps/drec-api/src/pods/device-group/dto/new-device-group.dto.ts
+++ b/apps/drec-api/src/pods/device-group/dto/new-device-group.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsArray, IsNumber } from 'class-validator';
+import { IsString, IsInt, Min } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class NewDeviceGroupDTO {
@@ -6,7 +6,8 @@ export class NewDeviceGroupDTO {
   @IsString()
   name: string;
 
-  @ApiProperty()
-  @IsArray()
+  @ApiProperty({ type: [Number] })
+  @IsInt({ each: true })
+  @Min(1, { each: true })
   deviceIds: number[];
 }

--- a/apps/drec-api/src/pods/device-group/dto/update-device.dto.ts
+++ b/apps/drec-api/src/pods/device-group/dto/update-device.dto.ts
@@ -1,0 +1,8 @@
+import { IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdateDeviceGroupDTO {
+  @ApiProperty()
+  @IsString()
+  name: string;
+}

--- a/apps/drec-api/src/pods/device/device.controller.ts
+++ b/apps/drec-api/src/pods/device/device.controller.ts
@@ -85,12 +85,12 @@ export class DeviceController {
   public async update(
     @UserDecorator() user: OrganizationUserDTO,
     @Param('id') id: number,
-    @Body() organizationToUpdate: UpdateDeviceDTO,
+    @Body() deviceToUpdate: UpdateDeviceDTO,
   ) {
     return await this.deviceService.update(
       user.organization.code,
       id,
-      organizationToUpdate,
+      deviceToUpdate,
     );
   }
 }

--- a/apps/drec-api/src/pods/device/device.entity.ts
+++ b/apps/drec-api/src/pods/device/device.entity.ts
@@ -41,6 +41,7 @@ export interface IDevice {
   impact_story?: string;
   data?: string;
   images?: string[];
+  groupId?: number;
 }
 
 @Entity()
@@ -146,4 +147,8 @@ export class Device extends ExtendedBaseEntity implements IDevice {
 
   @Column('text', { nullable: true, array: true })
   images: string[];
+
+  @Column({ nullable: true })
+  @IsString()
+  groupId: number;
 }

--- a/apps/drec-api/src/pods/device/device.service.ts
+++ b/apps/drec-api/src/pods/device/device.service.ts
@@ -130,7 +130,7 @@ export class DeviceService {
       groupId,
     );
     if (deviceExists) {
-      const message = `Device already added to this group`;
+      const message = `Device with id: ${currentDevice.id} already added to this group`;
       this.logger.error(message);
       throw new ConflictException({
         success: false,
@@ -138,7 +138,7 @@ export class DeviceService {
       });
     }
     if (currentDevice.groupId) {
-      const message = `Device already belongs to a group`;
+      const message = `Device with id: ${currentDevice.id} already belongs to a group`;
       this.logger.error(message);
       throw new ConflictException({
         success: false,
@@ -149,7 +149,9 @@ export class DeviceService {
       organizationOwnerCode &&
       currentDevice.registrant_organisation_code !== organizationOwnerCode
     ) {
-      throw new NotAcceptableException(`Device belongs to a different owner`);
+      throw new NotAcceptableException(
+        `Device with id: ${currentDevice.id} belongs to a different owner`,
+      );
     }
     currentDevice.groupId = groupId;
     return await this.repository.save(currentDevice);

--- a/apps/drec-api/src/pods/device/device.service.ts
+++ b/apps/drec-api/src/pods/device/device.service.ts
@@ -125,10 +125,6 @@ export class DeviceService {
     groupId: number,
     organizationOwnerCode?: string,
   ): Promise<Device> {
-    // const currentDevice = await this.findOne(deviceId);
-    // if (!currentDevice) {
-    //   throw new NotFoundException(`No device found with id ${deviceId}`);
-    // }
     const deviceExists = await this.getDeviceForGroup(
       currentDevice.id,
       groupId,

--- a/apps/drec-api/test/device.e2e-spec.ts
+++ b/apps/drec-api/test/device.e2e-spec.ts
@@ -42,7 +42,8 @@ describe('Device tests', () => {
       databaseService,
       configService,
     } = await bootstrapTestInstance());
-    await databaseService.truncate('user', 'device');
+    await databaseService.truncate('user', 'device', 'organization');
+
     await app.init();
   });
 
@@ -70,7 +71,7 @@ describe('Device tests', () => {
     await loginUser(loggedUser);
     const { body: devices } = await requestDevice('', HttpStatus.OK);
     expect(devices).to.be.instanceOf(Array);
-    expect(devices).to.have.length(3);
+    expect(devices).to.have.length(4);
   });
 
   it('should retrieve device by id', async () => {

--- a/apps/drec-api/test/group-devices.e2e-spec.ts
+++ b/apps/drec-api/test/group-devices.e2e-spec.ts
@@ -92,7 +92,7 @@ describe('Device Group tests', () => {
     );
     const newDeviceGroup: NewDeviceGroupDTO = {
       name: 'test-device-group-2',
-      deviceIds: [firstBatch[0], secondBatch[0]],
+      deviceIds: [firstBatch[0].id, secondBatch[0].id],
     };
     await postDeviceGroup('', HttpStatus.NOT_ACCEPTABLE, newDeviceGroup);
   });
@@ -201,7 +201,7 @@ describe('Device Group tests', () => {
     );
     const newDeviceGroup: NewDeviceGroupDTO = {
       name: 'test-device-group',
-      deviceIds: [firstBatch[0]],
+      deviceIds: [firstBatch[0].id],
     };
     return await postDeviceGroup('', HttpStatus.CREATED, newDeviceGroup);
   };

--- a/apps/drec-api/test/group-devices.e2e-spec.ts
+++ b/apps/drec-api/test/group-devices.e2e-spec.ts
@@ -1,0 +1,210 @@
+/* eslint-disable no-unused-expressions */
+import { HttpStatus, INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { ConfigService } from '@nestjs/config';
+import { DatabaseService } from '@energyweb/origin-backend-utils';
+
+import { bootstrapTestInstance } from './drec-api';
+import { UserService } from '../src/pods/user/user.service';
+import { OrganizationService } from '../src/pods/organization';
+import { seed, testOrgs } from './seed';
+import { expect } from 'chai';
+import { before, after } from 'mocha';
+import { DeviceService } from '../src/pods/device/device.service';
+import {
+  NewDeviceGroupDTO,
+  UpdateDeviceGroupDTO,
+} from '../src/pods/device-group/dto';
+import { DeviceGroupService } from '../src/pods/device-group/device-group.service';
+import { Device } from '../src/pods/device';
+
+describe('Device Group tests', () => {
+  let app: INestApplication;
+  let organizationService: OrganizationService;
+  let userService: UserService;
+  let deviceService: DeviceService;
+  let deviceGroupService: DeviceGroupService;
+  let databaseService: DatabaseService;
+  let configService: ConfigService;
+  let currentAccessToken: string;
+
+  before(async () => {
+    ({
+      app,
+      organizationService,
+      userService,
+      deviceService,
+      databaseService,
+      configService,
+    } = await bootstrapTestInstance());
+    await databaseService.truncate('user', 'device', 'organization');
+
+    await app.init();
+  });
+
+  after(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await seed({
+      userService,
+      organizationService,
+      deviceService,
+    });
+  });
+
+  afterEach(async () => {
+    await databaseService.cleanUp();
+  });
+
+  it('should create a device group', async () => {
+    const { body: createdGroup } = await createDeviceGroup();
+    expect(createdGroup.name).to.eq('test-device-group');
+  });
+
+  it('should update a device group', async () => {
+    const { body: createdGroup } = await createDeviceGroup();
+    const updateDeviceGrouo: UpdateDeviceGroupDTO = {
+      name: 'updated-device-group',
+    };
+    const { body: updatedDevice } = await updateDeviceGroup(
+      createdGroup.id,
+      HttpStatus.OK,
+      updateDeviceGrouo,
+    );
+    expect(updatedDevice.name).to.equal('updated-device-group');
+  });
+
+  it('should return Not Acceptable when creating a group with device from different owner', async () => {
+    const loggedUser = {
+      email: 'admin2@mailinator.com',
+      password: 'test',
+    };
+    await loginUser(loggedUser);
+    const { body: devices } = await requestDevice('', HttpStatus.OK);
+    const firstBatch = devices.filter(
+      (device: Device) =>
+        device.registrant_organisation_code === testOrgs[0].code,
+    );
+    const secondBatch = devices.filter(
+      (device: Device) =>
+        device.registrant_organisation_code === testOrgs[3].code,
+    );
+    const newDeviceGroup: NewDeviceGroupDTO = {
+      name: 'test-device-group-2',
+      deviceIds: [firstBatch[0], secondBatch[0]],
+    };
+    await postDeviceGroup('', HttpStatus.NOT_ACCEPTABLE, newDeviceGroup);
+  });
+
+  it('should retrieve all device groups', async () => {
+    await createDeviceGroup();
+    const { body: deviceGroups } = await requestDeviceGroup('', HttpStatus.OK);
+    expect(deviceGroups).to.be.instanceOf(Array);
+    expect(deviceGroups).to.have.length(1);
+  });
+
+  it('should retrieve device group by id', async () => {
+    await createDeviceGroup();
+    const { body: deviceGroups } = await requestDeviceGroup('', HttpStatus.OK);
+    const { body: deviceGroup } = await requestDeviceGroup(
+      deviceGroups[0].id,
+      HttpStatus.OK,
+    );
+    expect(deviceGroup.name).to.equal('test-device-group');
+    expect(deviceGroup.devices).to.be.instanceOf(Array);
+    expect(deviceGroup.devices).to.have.length(1);
+  });
+
+  it('should delete device group', async () => {
+    await createDeviceGroup();
+    const { body: deviceGroups } = await requestDeviceGroup('', HttpStatus.OK);
+    await deleteDeviceGroup(deviceGroups[0].id, HttpStatus.OK);
+  });
+
+  const createDeviceGroup = async (): Promise<any> => {
+    const loggedUser = {
+      email: 'admin2@mailinator.com',
+      password: 'test',
+    };
+    await loginUser(loggedUser);
+    const { body: devices } = await requestDevice('', HttpStatus.OK);
+    const firstBatch = devices.filter(
+      (device: Device) =>
+        device.registrant_organisation_code === testOrgs[0].code,
+    );
+    const newDeviceGroup: NewDeviceGroupDTO = {
+      name: 'test-device-group',
+      deviceIds: [firstBatch[0]],
+    };
+    return await postDeviceGroup('', HttpStatus.CREATED, newDeviceGroup);
+  };
+
+  const requestDevice = async (url: string, status: HttpStatus): Promise<any> =>
+    await request(app.getHttpServer())
+      .get(`/device/${url}`)
+      .set('Authorization', `Bearer ${currentAccessToken}`)
+      .expect(status);
+
+  const requestDeviceGroup = async (
+    url: string,
+    status: HttpStatus,
+  ): Promise<any> =>
+    await request(app.getHttpServer())
+      .get(`/device-group/${url}`)
+      .set('Authorization', `Bearer ${currentAccessToken}`)
+      .expect(status);
+
+  const updateDeviceGroup = async (
+    url: string,
+    status: HttpStatus,
+    body: Partial<UpdateDeviceGroupDTO>,
+  ): Promise<any> =>
+    await request(app.getHttpServer())
+      .patch(`/device-group/${url}`)
+      .send({
+        ...body,
+      })
+      .set('Authorization', `Bearer ${currentAccessToken}`)
+      .expect(status);
+
+  const postDeviceGroup = async (
+    url: string,
+    status: HttpStatus,
+    body: NewDeviceGroupDTO,
+  ): Promise<any> =>
+    await request(app.getHttpServer())
+      .post(`/device-group/${url}`)
+      .send({
+        ...body,
+      })
+      .set('Authorization', `Bearer ${currentAccessToken}`)
+      .expect(status);
+
+  const deleteDeviceGroup = async (
+    url: string,
+    status: HttpStatus,
+  ): Promise<any> =>
+    await request(app.getHttpServer())
+      .delete(`/device-group/${url}`)
+      .set('Authorization', `Bearer ${currentAccessToken}`)
+      .expect(status);
+
+  const loginUser = async (loggedUser: {
+    email: string;
+    password: string;
+  }): Promise<any> => {
+    const {
+      body: { accessToken },
+    } = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({
+        username: loggedUser.email,
+        password: loggedUser.password,
+      })
+      .expect(HttpStatus.OK);
+
+    currentAccessToken = accessToken;
+  };
+});

--- a/apps/drec-api/test/group-devices.e2e-spec.ts
+++ b/apps/drec-api/test/group-devices.e2e-spec.ts
@@ -16,7 +16,6 @@ import {
   NewDeviceGroupDTO,
   UpdateDeviceGroupDTO,
 } from '../src/pods/device-group/dto';
-import { DeviceGroupService } from '../src/pods/device-group/device-group.service';
 import { Device } from '../src/pods/device';
 
 describe('Device Group tests', () => {
@@ -24,7 +23,6 @@ describe('Device Group tests', () => {
   let organizationService: OrganizationService;
   let userService: UserService;
   let deviceService: DeviceService;
-  let deviceGroupService: DeviceGroupService;
   let databaseService: DatabaseService;
   let configService: ConfigService;
   let currentAccessToken: string;
@@ -79,7 +77,7 @@ describe('Device Group tests', () => {
 
   it('should return Not Acceptable when creating a group with device from different owner', async () => {
     const loggedUser = {
-      email: 'admin2@mailinator.com',
+      email: 'buyer2@mailinator.com',
       password: 'test',
     };
     await loginUser(loggedUser);
@@ -126,7 +124,7 @@ describe('Device Group tests', () => {
 
   it('should add devices to a device group', async () => {
     const loggedUser = {
-      email: 'admin2@mailinator.com',
+      email: 'buyer2@mailinator.com',
       password: 'test',
     };
     await loginUser(loggedUser);
@@ -159,7 +157,7 @@ describe('Device Group tests', () => {
 
   it('should remove devices from a device group', async () => {
     const loggedUser = {
-      email: 'admin2@mailinator.com',
+      email: 'buyer2@mailinator.com',
       password: 'test',
     };
     await loginUser(loggedUser);
@@ -192,7 +190,7 @@ describe('Device Group tests', () => {
 
   const createDeviceGroup = async (): Promise<any> => {
     const loggedUser = {
-      email: 'admin2@mailinator.com',
+      email: 'buyer2@mailinator.com',
       password: 'test',
     };
     await loginUser(loggedUser);

--- a/apps/drec-api/test/group-devices.e2e-spec.ts
+++ b/apps/drec-api/test/group-devices.e2e-spec.ts
@@ -188,6 +188,43 @@ describe('Device Group tests', () => {
     expect(updateDeviceGroup.devices).to.have.length(0);
   });
 
+  it('non-owner should not be able to remove device from group', async () => {
+    const loggedUser = {
+      email: 'buyer2@mailinator.com',
+      password: 'test',
+    };
+    await loginUser(loggedUser);
+    const { body: devices } = await requestDevice('', HttpStatus.OK);
+    const firstBatch = devices.filter(
+      (device: Device) =>
+        device.registrant_organisation_code === testOrgs[3].code,
+    );
+    const newDeviceGroup: NewDeviceGroupDTO = {
+      name: 'test-device-group-3',
+      deviceIds: [firstBatch[0].id],
+    };
+    await postDeviceGroup('', HttpStatus.CREATED, newDeviceGroup);
+
+    const { body: deviceGroups } = await requestDeviceGroup('', HttpStatus.OK);
+    const { body: deviceGroup } = await requestDeviceGroup(
+      deviceGroups[0].id,
+      HttpStatus.OK,
+    );
+    const deviceIds: DeviceIdsDTO = {
+      deviceIds: [firstBatch[0].id],
+    };
+    const newLoggedUser = {
+      email: 'admin2@mailinator.com',
+      password: 'test',
+    };
+    await loginUser(newLoggedUser);
+    await addRemoveDevices(
+      `remove/${deviceGroup.id}`,
+      HttpStatus.NOT_FOUND,
+      deviceIds,
+    );
+  });
+
   const createDeviceGroup = async (): Promise<any> => {
     const loggedUser = {
       email: 'buyer2@mailinator.com',

--- a/apps/drec-api/test/organization.e2e-spec.ts
+++ b/apps/drec-api/test/organization.e2e-spec.ts
@@ -76,7 +76,7 @@ describe('Organization tests', () => {
       HttpStatus.OK,
     );
     expect(organizations).to.be.instanceOf(Array);
-    expect(organizations).to.have.length(3);
+    expect(organizations).to.have.length(4);
   });
 
   it('should retrieve user`s organization', async () => {

--- a/apps/drec-api/test/reads.e2e-spec.ts
+++ b/apps/drec-api/test/reads.e2e-spec.ts
@@ -30,7 +30,7 @@ describe('Reads tests', () => {
       deviceService,
       configService,
     } = await bootstrapTestInstance());
-    await databaseService.truncate('user', 'organization');
+    await databaseService.truncate('user', 'device', 'organization');
 
     await app.init();
     // clean influxdb

--- a/apps/drec-api/test/seed.ts
+++ b/apps/drec-api/test/seed.ts
@@ -54,6 +54,20 @@ export const testOrgs = [
     blockchainAccountAddress: 'blockchainAccountAddress333',
     role: Role.Admin,
   },
+  {
+    code: 'D0013',
+    name: 'Device Owner 2',
+    address: 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr',
+    primaryContact: 'Maria Robbins',
+    telephone: '81-3-6889-2713',
+    email: 'owner3@mailinator.com',
+    regNumber: '123456789',
+    vatNumber: '123456789',
+    regAddress: 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr',
+    country: 'DE',
+    blockchainAccountAddress: 'blockchainAccountAddress444',
+    role: Role.DeviceOwner,
+  },
 ];
 
 export const testUsers: CreateUserDTO[] = [
@@ -74,6 +88,12 @@ export const testUsers: CreateUserDTO[] = [
     email: 'admin2@mailinator.com',
     password: 'test',
     organizationId: 'A0012',
+  },
+  {
+    username: 'MariaRobbins',
+    email: 'owner3@mailinator.com',
+    password: 'test',
+    organizationId: 'D0013',
   },
 ];
 
@@ -156,6 +176,32 @@ const testDevices: Omit<DeviceDTO, 'status'>[] = [
     data: '',
     images: [],
   },
+  {
+    id: 5,
+    drecID: 'DREC05',
+    registrant_organisation_code: 'D0013',
+    project_name: 'Device 5',
+    address: 'Somewhere far away',
+    latitude: '34.921213',
+    longitude: '135.717309',
+    country_code: 'DE',
+    zip_code: 111111,
+    fuel_code: 'ES100',
+    device_type_code: 'TC110',
+    installation_configuration: Installation.StandAlone,
+    capacity: 1750,
+    commissioning_date: '2012-07-01',
+    grid_interconnection: true,
+    off_taker: OffTaker.Commercial,
+    sector: Sector.Agriculture,
+    standard_compliance: StandardCompliance.IREC,
+    yield_value: 1000,
+    generators_ids: [],
+    labels: '',
+    impact_story: '',
+    data: '',
+    images: [],
+  },
 ];
 
 export type Services = {
@@ -169,21 +215,24 @@ export const seed = async ({
   organizationService,
   deviceService,
 }: Services) => {
-  const [user1, user2, user3] = testUsers;
+  const [user1, user2, user3, user4] = testUsers;
 
   await userService.seed(user1);
   await userService.seed(user2);
   await userService.seed(user3);
+  await userService.seed(user4);
 
-  const [org1, org2, org3] = testOrgs;
+  const [org1, org2, org3, org4] = testOrgs;
 
   await organizationService.seed(org1);
   await organizationService.seed(org2);
   await organizationService.seed(org3);
+  await organizationService.seed(org4);
 
-  const [device1, device2, device3] = testDevices;
+  const [device1, device2, device3, device4] = testDevices;
 
   await deviceService.seed(device1);
   await deviceService.seed(device2);
   await deviceService.seed(device3);
+  await deviceService.seed(device4);
 };


### PR DESCRIPTION
Requirements:

After filtering, the org user of role Buyer (and Admin) should be able to connect the selected devices to a group. 
Devices can only be in one group. 
Organizations can have multiple device groups. 
Only devices from one owner can be grouped: The first device defines the possible owner (org code).
The device group should have a name and a list of devices (by ID).
As a user, I want to be able to add and remove devices from a device group. 
Given I am a user of the organization that created the device group
When I remove or add a device from the group
Then the device group should be edited accordingly
Three endpoints:
Add/ Remove device
Rename
Delete

Implementation:
1.	Devices will have a new column – groupId
2.	When a group is created, we have:
a.	Group name
b.	Group organization – based on the user organization who created the group (must have role Buyer)
c.	Each device belongs to a single group
3.	With the list of ids, we do the following:
a.	Get the first id of the list and get the device with that id
b.	If the id is not found, we take the next element and so on until a device is found
c.	The first device will give the organization owner of the devices to be used in the group
d.	Every other device MUST be from the same organization otherwise we don`t add it to the group
