### PR TITLE
feat(drec-api) attributes for device groups

### DIFF
--- a/apps/drec-api/migrations/1633366638472-DeviceGroupAttributes.ts
+++ b/apps/drec-api/migrations/1633366638472-DeviceGroupAttributes.ts
@@ -1,0 +1,105 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class DeviceGroupAttributes1633366638472 implements MigrationInterface {
+  name = 'DeviceGroupAttributes1633366638472';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "device_group" ADD "fuelCode" character varying NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "device_group" ADD "countryCode" character varying NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "device_group" ADD "standardCompliance" character varying NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "device_group" ADD "deviceTypeCodes" text array NOT NULL`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "device_group_offtakers_enum" AS ENUM('School', 'HealthFacility', 'Residential', 'Commercial', 'Industrial', 'PublicSector')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "device_group" ADD "offTakers" "device_group_offtakers_enum" array NOT NULL DEFAULT '{}'`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "device_group_installationconfigurations_enum" AS ENUM('StandAlone', 'Microgrid')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "device_group" ADD "installationConfigurations" "device_group_installationconfigurations_enum" array NOT NULL DEFAULT '{}'`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "device_group_sectors_enum" AS ENUM('Agriculture', 'Manufacturing', 'PublicServices', 'Telecom ', 'Residential', 'Mining', 'Education', 'Health', 'Textiles  ', 'Financial ')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "device_group" ADD "sectors" "device_group_sectors_enum" array NOT NULL DEFAULT '{}'`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "device_group_commissioningdaterange_enum" AS ENUM('Year1', 'Year2', 'Year3', 'Year4', 'Year5', '6-10years', '11-15years', '15+years')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "device_group" ADD "commissioningDateRange" "device_group_commissioningdaterange_enum" array NOT NULL DEFAULT '{}'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "device_group" ADD "gridInterconnection" boolean NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "device_group" ADD "aggregatedCapacity" integer NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "device_group" ADD "capacityRange" character varying NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "device_group" ADD "yieldValue" integer NOT NULL DEFAULT '1000'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "device_group" ADD "labels" character varying`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "device_group" DROP COLUMN "labels"`);
+    await queryRunner.query(
+      `ALTER TABLE "device_group" DROP COLUMN "yieldValue"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "device_group" DROP COLUMN "capacityRange"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "device_group" DROP COLUMN "aggregatedCapacity"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "device_group" DROP COLUMN "gridInterconnection"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "device_group" DROP COLUMN "commissioningDateRange"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "device_group_commissioningdaterange_enum"`,
+    );
+    await queryRunner.query(`ALTER TABLE "device_group" DROP COLUMN "sectors"`);
+    await queryRunner.query(`DROP TYPE "device_group_sectors_enum"`);
+    await queryRunner.query(
+      `ALTER TABLE "device_group" DROP COLUMN "installationConfigurations"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "device_group_installationconfigurations_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "device_group" DROP COLUMN "offTakers"`,
+    );
+    await queryRunner.query(`DROP TYPE "device_group_offtakers_enum"`);
+    await queryRunner.query(
+      `ALTER TABLE "device_group" DROP COLUMN "deviceTypeCodes"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "device_group" DROP COLUMN "standardCompliance"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "device_group" DROP COLUMN "countryCode"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "device_group" DROP COLUMN "fuelCode"`,
+    );
+  }
+}

--- a/apps/drec-api/src/models/DeviceGroup.ts
+++ b/apps/drec-api/src/models/DeviceGroup.ts
@@ -1,8 +1,34 @@
 import { IDevice } from '.';
+import {
+  CapacityRange,
+  CommissioningDateRange,
+  Installation,
+  OffTaker,
+  Sector,
+  StandardCompliance,
+} from '../utils/enums';
 
 export interface IDeviceGroup {
   id: number;
   name: string;
   organizationId: number;
+  fuelCode: string;
+  countryCode: string;
+  standardCompliance: StandardCompliance;
+
+  deviceTypeCodes: string[];
+  offTakers: OffTaker[];
+  installationConfigurations: Installation[];
+  sectors: Sector[];
+  gridInterconnection: boolean; // True - all devices have gridInterconnection true, if one has false, then this value is false
+  aggregatedCapacity: number; // total capacity of all devices beloning to this group
+
+  capacityRange: CapacityRange;
+  commissioningDateRange: CommissioningDateRange[];
+
+  yieldValue?: number; // ideally all underlying devices should have the same, otherwise take average?
+
+  labels?: string;
+
   devices?: IDevice[];
 }

--- a/apps/drec-api/src/models/DeviceGroup.ts
+++ b/apps/drec-api/src/models/DeviceGroup.ts
@@ -1,4 +1,4 @@
-import { IDevice } from '.';
+import { IDevice } from './Device';
 import {
   CapacityRange,
   CommissioningDateRange,

--- a/apps/drec-api/src/pods/device-group/device-group.controller.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.controller.ts
@@ -122,7 +122,7 @@ export class DeviceGroupController {
 
   @Patch('/:id')
   @UseGuards(RolesGuard)
-  @Roles(Role.Admin)
+  @Roles(Role.DeviceOwner, Role.Admin)
   @ApiResponse({
     status: HttpStatus.OK,
     type: UpdateDeviceGroupDTO,

--- a/apps/drec-api/src/pods/device-group/device-group.entity.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.entity.ts
@@ -1,7 +1,21 @@
 import { ExtendedBaseEntity } from '@energyweb/origin-backend-utils';
 import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
-import { IsString, IsNotEmpty } from 'class-validator';
+import {
+  IsString,
+  IsNotEmpty,
+  IsEnum,
+  IsBoolean,
+  IsNumber,
+} from 'class-validator';
 import { IDevice, IDeviceGroup } from '../../models';
+import {
+  CapacityRange,
+  CommissioningDateRange,
+  Installation,
+  OffTaker,
+  Sector,
+  StandardCompliance,
+} from '../../utils/enums';
 
 @Entity()
 export class DeviceGroup extends ExtendedBaseEntity implements IDeviceGroup {
@@ -15,6 +29,73 @@ export class DeviceGroup extends ExtendedBaseEntity implements IDeviceGroup {
 
   @Column()
   organizationId: number;
+
+  @Column()
+  @IsString()
+  fuelCode: string;
+
+  @Column()
+  @IsString()
+  countryCode: string;
+
+  @Column()
+  @IsEnum(StandardCompliance)
+  standardCompliance: StandardCompliance;
+
+  @Column('text', { array: true })
+  deviceTypeCodes: string[];
+
+  @Column({
+    type: 'enum',
+    enum: OffTaker,
+    array: true,
+    default: [],
+  })
+  offTakers: OffTaker[];
+
+  @Column({
+    type: 'enum',
+    enum: Installation,
+    array: true,
+    default: [],
+  })
+  installationConfigurations: Installation[];
+
+  @Column({
+    type: 'enum',
+    enum: Sector,
+    array: true,
+    default: [],
+  })
+  sectors: Sector[];
+
+  @Column({
+    type: 'enum',
+    enum: CommissioningDateRange,
+    array: true,
+    default: [],
+  })
+  commissioningDateRange: CommissioningDateRange[];
+
+  @Column()
+  @IsBoolean()
+  gridInterconnection: boolean;
+
+  @Column()
+  @IsNumber()
+  aggregatedCapacity: number;
+
+  @Column()
+  @IsEnum(CapacityRange)
+  capacityRange: CapacityRange;
+
+  @Column({ default: 1000 })
+  @IsNumber()
+  yieldValue: number;
+
+  @Column({ nullable: true })
+  @IsString()
+  labels: string;
 
   devices?: IDevice[];
 }

--- a/apps/drec-api/src/pods/device-group/device-group.entity.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.entity.ts
@@ -6,6 +6,7 @@ import {
   IsEnum,
   IsBoolean,
   IsNumber,
+  IsOptional,
 } from 'class-validator';
 import { IDevice, IDeviceGroup } from '../../models';
 import {
@@ -94,6 +95,7 @@ export class DeviceGroup extends ExtendedBaseEntity implements IDeviceGroup {
   yieldValue: number;
 
   @Column({ nullable: true })
+  @IsOptional()
   @IsString()
   labels: string;
 

--- a/apps/drec-api/src/pods/device-group/device-group.service.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.service.ts
@@ -11,7 +11,6 @@ import { DeviceIdsDTO, NewDeviceGroupDTO, UpdateDeviceGroupDTO } from './dto';
 import { DeviceGroup } from './device-group.entity';
 import { Device } from '../device/device.entity';
 import { IDevice } from '../../models';
-import { CommissioningDateRange } from '../../utils/enums';
 
 @Injectable()
 export class DeviceGroupService {

--- a/apps/drec-api/src/pods/device-group/device-group.service.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.service.ts
@@ -11,6 +11,7 @@ import { DeviceIdsDTO, NewDeviceGroupDTO, UpdateDeviceGroupDTO } from './dto';
 import { DeviceGroup } from './device-group.entity';
 import { Device } from '../device/device.entity';
 import { IDevice } from '../../models';
+import { CommissioningDateRange } from '../../utils/enums';
 
 @Injectable()
 export class DeviceGroupService {
@@ -44,10 +45,9 @@ export class DeviceGroupService {
   ): Promise<DeviceGroup> {
     await this.checkNameConflict(data.name);
     const group = await this.repository.save({
-      name: data.name,
       organizationId,
+      ...data,
     });
-
     // For each device id, add the groupId but make sure they all belong to the same owner
     const devices = await this.deviceService.findByIds(data.deviceIds);
 
@@ -124,7 +124,11 @@ export class DeviceGroupService {
     const deviceGroup = await this.findDeviceGroupById(id, organizationId);
 
     deviceGroup.name = data.name;
+    console.log('deviceGroup: ', deviceGroup);
+
     const updatedGroup = await this.repository.save(deviceGroup);
+    console.log('updatedGroup: ', updatedGroup);
+
     updatedGroup.devices = await this.deviceService.findForGroup(
       deviceGroup.id,
     );

--- a/apps/drec-api/src/pods/device-group/device-group.service.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.service.ts
@@ -124,10 +124,8 @@ export class DeviceGroupService {
     const deviceGroup = await this.findDeviceGroupById(id, organizationId);
 
     deviceGroup.name = data.name;
-    console.log('deviceGroup: ', deviceGroup);
 
     const updatedGroup = await this.repository.save(deviceGroup);
-    console.log('updatedGroup: ', updatedGroup);
 
     updatedGroup.devices = await this.deviceService.findForGroup(
       deviceGroup.id,

--- a/apps/drec-api/src/pods/device-group/dto/device-group.dto.ts
+++ b/apps/drec-api/src/pods/device-group/dto/device-group.dto.ts
@@ -1,6 +1,22 @@
-import { IsString, IsNumber } from 'class-validator';
+import {
+  IsString,
+  IsNumber,
+  IsEnum,
+  IsArray,
+  IsNotEmpty,
+  IsBoolean,
+  IsOptional,
+} from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { IDeviceGroup } from '../../../models';
+import {
+  CapacityRange,
+  CommissioningDateRange,
+  Installation,
+  OffTaker,
+  Sector,
+  StandardCompliance,
+} from '../../../utils/enums';
 
 export class DeviceGroupDTO implements IDeviceGroup {
   @ApiProperty()
@@ -14,4 +30,78 @@ export class DeviceGroupDTO implements IDeviceGroup {
   @ApiProperty()
   @IsNumber()
   organizationId: number;
+
+  @ApiProperty()
+  @IsString()
+  countryCode: string;
+
+  @ApiProperty()
+  @IsString()
+  fuelCode: string;
+
+  @ApiProperty()
+  @IsEnum(StandardCompliance)
+  standardCompliance: StandardCompliance;
+
+  @ApiProperty({ type: [String] })
+  @IsArray()
+  deviceTypeCodes: string[];
+
+  @ApiProperty({
+    description: 'List of off takers',
+    isArray: true,
+    enum: OffTaker,
+  })
+  @IsEnum(OffTaker, { each: true })
+  @IsNotEmpty()
+  offTakers: OffTaker[];
+
+  @ApiProperty({
+    description: 'List of installations',
+    isArray: true,
+    enum: Installation,
+  })
+  @IsEnum(Installation, { each: true })
+  @IsNotEmpty()
+  installationConfigurations: Installation[];
+
+  @ApiProperty({
+    description: 'List of sectors',
+    isArray: true,
+    enum: Sector,
+  })
+  @IsEnum(Sector, { each: true })
+  @IsNotEmpty()
+  sectors: Sector[];
+
+  @ApiProperty()
+  @IsBoolean()
+  gridInterconnection: boolean;
+
+  @ApiProperty()
+  @IsNumber()
+  aggregatedCapacity: number;
+
+  @ApiProperty()
+  @IsEnum(CapacityRange)
+  capacityRange: CapacityRange;
+
+  @ApiProperty({
+    description: 'List of commissioning date ranges',
+    isArray: true,
+    enum: CommissioningDateRange,
+  })
+  @IsEnum(CommissioningDateRange, { each: true })
+  @IsNotEmpty()
+  commissioningDateRange: CommissioningDateRange[];
+
+  @ApiProperty()
+  @IsNumber()
+  @IsOptional()
+  yieldValue: number;
+
+  @ApiProperty()
+  @IsString()
+  @IsOptional()
+  labels: string;
 }

--- a/apps/drec-api/src/pods/device-group/dto/new-device-group.dto.ts
+++ b/apps/drec-api/src/pods/device-group/dto/new-device-group.dto.ts
@@ -1,7 +1,28 @@
-import { IsString, IsInt, Min } from 'class-validator';
+import {
+  IsString,
+  IsInt,
+  Min,
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+} from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { IDeviceGroup } from '../../../models';
+import {
+  StandardCompliance,
+  OffTaker,
+  Installation,
+  Sector,
+  CapacityRange,
+  CommissioningDateRange,
+} from '../../../utils/enums';
 
-export class NewDeviceGroupDTO {
+export class NewDeviceGroupDTO
+  implements Omit<IDeviceGroup, 'id' | 'organizationId'>
+{
   @ApiProperty()
   @IsString()
   name: string;
@@ -10,4 +31,78 @@ export class NewDeviceGroupDTO {
   @IsInt({ each: true })
   @Min(1, { each: true })
   deviceIds: number[];
+
+  @ApiProperty()
+  @IsString()
+  countryCode: string;
+
+  @ApiProperty()
+  @IsString()
+  fuelCode: string;
+
+  @ApiProperty()
+  @IsEnum(StandardCompliance)
+  standardCompliance: StandardCompliance;
+
+  @ApiProperty({ type: [String] })
+  @IsArray()
+  deviceTypeCodes: string[];
+
+  @ApiProperty({
+    description: 'List of off takers',
+    isArray: true,
+    enum: OffTaker,
+  })
+  @IsEnum(OffTaker, { each: true })
+  @IsNotEmpty()
+  offTakers: OffTaker[];
+
+  @ApiProperty({
+    description: 'List of installations',
+    isArray: true,
+    enum: Installation,
+  })
+  @IsEnum(Installation, { each: true })
+  @IsNotEmpty()
+  installationConfigurations: Installation[];
+
+  @ApiProperty({
+    description: 'List of sectors',
+    isArray: true,
+    enum: Sector,
+  })
+  @IsEnum(Sector, { each: true })
+  @IsNotEmpty()
+  sectors: Sector[];
+
+  @ApiProperty()
+  @IsBoolean()
+  gridInterconnection: boolean;
+
+  @ApiProperty()
+  @IsNumber()
+  aggregatedCapacity: number;
+
+  @ApiProperty()
+  @IsEnum(CapacityRange)
+  capacityRange: CapacityRange;
+
+  @ApiProperty({
+    description: 'List of commissioning date ranges',
+    isArray: true,
+    enum: CommissioningDateRange,
+  })
+  @IsEnum(CommissioningDateRange, { each: true })
+  @IsNotEmpty()
+  commissioningDateRange: CommissioningDateRange[];
+
+  @ApiProperty({ default: 1000 })
+  @IsNumber()
+  @IsOptional()
+  yieldValue: number;
+
+  @ApiProperty()
+  @IsString()
+  @IsOptional()
+  labels: string;
 }

--- a/apps/drec-api/src/pods/device-group/dto/update-device.dto.ts
+++ b/apps/drec-api/src/pods/device-group/dto/update-device.dto.ts
@@ -1,8 +1,9 @@
-import { IsString } from 'class-validator';
+import { IsNotEmpty, IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdateDeviceGroupDTO {
   @ApiProperty()
   @IsString()
+  @IsNotEmpty()
   name: string;
 }

--- a/apps/drec-api/src/pods/issuer/issuer.service.ts
+++ b/apps/drec-api/src/pods/issuer/issuer.service.ts
@@ -76,6 +76,7 @@ export class IssuerService {
     if (!devicesWithoutGroups.length) {
       return;
     }
+
     const ownerGroupedDevices = values(
       groupBy(devicesWithoutGroups, deviceGroupRule1),
     );
@@ -84,17 +85,18 @@ export class IssuerService {
       ownerGroupedDevices.flatMap(async (ownerBasedGroup: IDevice[], i) => {
         values(groupBy(ownerBasedGroup, deviceGroupRule2)).map(
           async (countryBasedGroup: IDevice[], j) => {
-            const categorizedGroup: IDeviceGroup = {
-              id: 0,
-              name: `Default Group ${ownerBasedGroup[i]?.organizationId}_${i}-${j}`,
-              organizationId: ownerBasedGroup[i]?.organizationId,
-              devices: countryBasedGroup,
-            };
-            return await this.issueCertificateForGroup(
-              categorizedGroup,
-              startDate,
-              endDate,
-            );
+            // const categorizedGroup: IDeviceGroup = {
+            //   id: 0,
+            //   name: `Default Group ${ownerBasedGroup[i]?.organizationId}_${i}-${j}`,
+            //   organizationId: ownerBasedGroup[i]?.organizationId,
+            //   devices: countryBasedGroup,
+            // };
+            // return await this.issueCertificateForGroup(
+            //   categorizedGroup,
+            //   startDate,
+            //   endDate,
+            // );
+            return;
           },
         );
       }),

--- a/apps/drec-api/src/utils/enums/capacity-range.enum.ts
+++ b/apps/drec-api/src/utils/enums/capacity-range.enum.ts
@@ -1,0 +1,9 @@
+export enum CapacityRange {
+  Between_0_50_w = '0-50watts',
+  Between_51_500_w = '51-500watts',
+  Between_501w_1kw = '501watts-1kW',
+  Between_1kw_50kw = '1.001kW-50kW',
+  Between_50kw_100kw = '50.001kW-100kW',
+  Between_101kw_1mw = '100.001kW-1MW',
+  Above_1mw = '1.001MW+',
+}

--- a/apps/drec-api/src/utils/enums/commissioning-date-range.enum.ts
+++ b/apps/drec-api/src/utils/enums/commissioning-date-range.enum.ts
@@ -1,0 +1,10 @@
+export enum CommissioningDateRange {
+  Year_1 = 'Year1',
+  Year_2 = 'Year2',
+  Year_3 = 'Year3',
+  Year_4 = 'Year4',
+  Year_5 = 'Year5',
+  Between_years_6_10 = '6-10years',
+  Between_years_11_15 = '11-15years',
+  Above_15_years = '15+years',
+}

--- a/apps/drec-api/src/utils/enums/index.ts
+++ b/apps/drec-api/src/utils/enums/index.ts
@@ -7,3 +7,5 @@ export * from './user-status.enum';
 export * from './organization-status.enum';
 export * from './device-status.enum';
 export * from './email-confirmation-response.enum';
+export * from './capacity-range.enum';
+export * from './commissioning-date-range.enum';

--- a/apps/drec-api/test/group-devices.e2e-spec.ts
+++ b/apps/drec-api/test/group-devices.e2e-spec.ts
@@ -18,6 +18,7 @@ import {
 } from '../src/pods/device-group/dto';
 import { Device } from '../src/pods/device';
 import { IFullOrganization } from '../src/models';
+import { CapacityRange, CommissioningDateRange } from '../src/utils/enums';
 
 describe('Device Group tests', () => {
   let app: INestApplication;
@@ -66,13 +67,13 @@ describe('Device Group tests', () => {
 
   it('should update a device group', async () => {
     const { body: createdGroup } = await createDeviceGroup();
-    const updateDeviceGrouo: UpdateDeviceGroupDTO = {
+    const updatedDeviceGroup: UpdateDeviceGroupDTO = {
       name: 'updated-device-group',
     };
     const { body: updatedDevice } = await updateDeviceGroup(
       createdGroup.id,
       HttpStatus.OK,
-      updateDeviceGrouo,
+      updatedDeviceGroup,
     );
     expect(updatedDevice.name).to.equal('updated-device-group');
   });
@@ -96,6 +97,19 @@ describe('Device Group tests', () => {
     const newDeviceGroup: NewDeviceGroupDTO = {
       name: 'test-device-group-2',
       deviceIds: [firstBatch[0].id, secondBatch[0].id],
+      countryCode: firstBatch[0]?.countryCode,
+      fuelCode: firstBatch[0]?.fuelCode,
+      standardCompliance: firstBatch[0]?.standardCompliance,
+      deviceTypeCodes: [firstBatch[0]?.deviceTypeCode],
+      offTakers: [firstBatch[0]?.offTaker],
+      installationConfigurations: [firstBatch[0]?.installationConfiguration],
+      sectors: [firstBatch[0]?.sector],
+      gridInterconnection: firstBatch[0]?.gridInterconnection,
+      aggregatedCapacity: firstBatch[0]?.capacity,
+      capacityRange: CapacityRange.Between_51_500_w,
+      commissioningDateRange: [CommissioningDateRange.Between_years_6_10],
+      yieldValue: firstBatch[0]?.yieldValue,
+      labels: firstBatch[0]?.labels,
     };
     await postDeviceGroup('', HttpStatus.NOT_ACCEPTABLE, newDeviceGroup);
   });
@@ -140,6 +154,19 @@ describe('Device Group tests', () => {
     const newDeviceGroup: NewDeviceGroupDTO = {
       name: 'test-device-group-2',
       deviceIds: [firstBatch[0]?.id],
+      countryCode: firstBatch[0]?.countryCode,
+      fuelCode: firstBatch[0]?.fuelCode,
+      standardCompliance: firstBatch[0]?.standardCompliance,
+      deviceTypeCodes: [firstBatch[0]?.deviceTypeCode],
+      offTakers: [firstBatch[0]?.offTaker],
+      installationConfigurations: [firstBatch[0]?.installationConfiguration],
+      sectors: [firstBatch[0]?.sector],
+      gridInterconnection: firstBatch[0]?.gridInterconnection,
+      aggregatedCapacity: firstBatch[0]?.capacity,
+      capacityRange: CapacityRange.Between_51_500_w,
+      commissioningDateRange: [CommissioningDateRange.Between_years_6_10],
+      yieldValue: firstBatch[0]?.yieldValue,
+      labels: firstBatch[0]?.labels,
     };
     await postDeviceGroup('', HttpStatus.CREATED, newDeviceGroup);
     const { body: deviceGroups } = await requestDeviceGroup('', HttpStatus.OK);
@@ -174,6 +201,19 @@ describe('Device Group tests', () => {
     const newDeviceGroup: NewDeviceGroupDTO = {
       name: 'test-device-group-3',
       deviceIds: [firstBatch[0].id],
+      countryCode: firstBatch[0]?.countryCode,
+      fuelCode: firstBatch[0]?.fuelCode,
+      standardCompliance: firstBatch[0]?.standardCompliance,
+      deviceTypeCodes: [firstBatch[0]?.deviceTypeCode],
+      offTakers: [firstBatch[0]?.offTaker],
+      installationConfigurations: [firstBatch[0]?.installationConfiguration],
+      sectors: [firstBatch[0]?.sector],
+      gridInterconnection: firstBatch[0]?.gridInterconnection,
+      aggregatedCapacity: firstBatch[0]?.capacity,
+      capacityRange: CapacityRange.Between_51_500_w,
+      commissioningDateRange: [CommissioningDateRange.Between_years_6_10],
+      yieldValue: firstBatch[0]?.yieldValue,
+      labels: firstBatch[0]?.labels,
     };
     await postDeviceGroup('', HttpStatus.CREATED, newDeviceGroup);
     const { body: deviceGroups } = await requestDeviceGroup('', HttpStatus.OK);
@@ -208,6 +248,19 @@ describe('Device Group tests', () => {
     const newDeviceGroup: NewDeviceGroupDTO = {
       name: 'test-device-group-3',
       deviceIds: [firstBatch[0].id],
+      countryCode: firstBatch[0]?.countryCode,
+      fuelCode: firstBatch[0]?.fuelCode,
+      standardCompliance: firstBatch[0]?.standardCompliance,
+      deviceTypeCodes: [firstBatch[0]?.deviceTypeCode],
+      offTakers: [firstBatch[0]?.offTaker],
+      installationConfigurations: [firstBatch[0]?.installationConfiguration],
+      sectors: [firstBatch[0]?.sector],
+      gridInterconnection: firstBatch[0]?.gridInterconnection,
+      aggregatedCapacity: firstBatch[0]?.capacity,
+      capacityRange: CapacityRange.Between_51_500_w,
+      commissioningDateRange: [CommissioningDateRange.Between_years_6_10],
+      yieldValue: firstBatch[0]?.yieldValue,
+      labels: firstBatch[0]?.labels,
     };
     await postDeviceGroup('', HttpStatus.CREATED, newDeviceGroup);
 
@@ -245,6 +298,19 @@ describe('Device Group tests', () => {
     const newDeviceGroup: NewDeviceGroupDTO = {
       name: 'test-device-group',
       deviceIds: [firstBatch[0]?.id],
+      countryCode: firstBatch[0]?.countryCode,
+      fuelCode: firstBatch[0]?.fuelCode,
+      standardCompliance: firstBatch[0]?.standardCompliance,
+      deviceTypeCodes: [firstBatch[0]?.deviceTypeCode],
+      offTakers: [firstBatch[0]?.offTaker],
+      installationConfigurations: [firstBatch[0]?.installationConfiguration],
+      sectors: [firstBatch[0]?.sector],
+      gridInterconnection: firstBatch[0]?.gridInterconnection,
+      aggregatedCapacity: firstBatch[0]?.capacity,
+      capacityRange: CapacityRange.Between_51_500_w,
+      commissioningDateRange: [CommissioningDateRange.Between_years_6_10],
+      yieldValue: firstBatch[0]?.yieldValue,
+      labels: firstBatch[0]?.labels,
     };
     return await postDeviceGroup('', HttpStatus.CREATED, newDeviceGroup);
   };


### PR DESCRIPTION
Because device group basically take the place of devices we need some way so that they can inherit the attributes of their underlying devices. 

This means it should have all the attributes of the device but where the device can only have either Offtaker School OR Hospital, the device group can have both [Hospital;School]

Non enum datafields capacity and comissioning date should be turned into following attributes

Datafields: 

- Fuel Type
- Country
- Standard Compliance
- Organization
- Device ID’s (list of all IDs)
- DREC ID's (list of all IDs)
- Group Name (auto generated from sorting criteria e.g.: Kenia Schools Microgrid I-REC)
- Device Types
- Offtaker
- Offtaker Industry
- Installation configuration
- Grid interconnection
- Aggregated Capacity (sum of all capacities)
- Single Capacities (capacity ranges that are found in group)
  - 0 - 50 watts
  -  51-500 watts
  -  501watts - 1 kW
  -  1.001kW - 50 kW
  -  50.001kW - 100 kW
  -  00.001 kW - 1MW
  -   1.001 MW+

- Commissioning Date / Age
  - Year 1
  -  Year 2
  -  Year 3
  -  Year 4
  -  Year 5
  -  6 - 10 years
  -  11-15 years
  -  15+ years

- yieldValue: 1000 (ideally all underlying devices should have the same, otherwise take average?)

- Labels (free list of lables)