### PR TITLE
feat(drec-api) handle leftover reads from issuance

### DIFF
--- a/apps/drec-api/migrations/1635785881039-DeviceGroupLeftoverReads.ts
+++ b/apps/drec-api/migrations/1635785881039-DeviceGroupLeftoverReads.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class DeviceGroupLeftoverReads1635785881039
+  implements MigrationInterface
+{
+  name = 'DeviceGroupLeftoverReads1635785881039';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "device_group" ADD "leftoverReads" numeric(10,2) DEFAULT '0'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "device_group" DROP COLUMN "leftoverReads"`,
+    );
+  }
+}

--- a/apps/drec-api/migrations/1635859358060-DeviceGroupLeftoverReads.ts
+++ b/apps/drec-api/migrations/1635859358060-DeviceGroupLeftoverReads.ts
@@ -1,13 +1,13 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class DeviceGroupLeftoverReads1635785881039
+export class DeviceGroupLeftoverReads1635859358060
   implements MigrationInterface
 {
-  name = 'DeviceGroupLeftoverReads1635785881039';
+  name = 'DeviceGroupLeftoverReads1635859358060';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `ALTER TABLE "device_group" ADD "leftoverReads" numeric(10,2) DEFAULT '0'`,
+      `ALTER TABLE "device_group" ADD "leftoverReads" double precision DEFAULT '0'`,
     );
   }
 

--- a/apps/drec-api/src/models/DeviceGroup.ts
+++ b/apps/drec-api/src/models/DeviceGroup.ts
@@ -31,6 +31,8 @@ export interface IDeviceGroup {
 
   labels?: string[];
 
+  leftoverReads?: number; // in KW
+
   devices?: DeviceDTO[];
   organization?: Pick<OrganizationDTO, 'name'>;
 

--- a/apps/drec-api/src/pods/device-group/device-group.entity.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.entity.ts
@@ -88,9 +88,7 @@ export class DeviceGroup extends ExtendedBaseEntity implements IDeviceGroup {
   buyerAddress: string;
 
   @Column({
-    type: 'decimal',
-    precision: 10,
-    scale: 2,
+    type: 'float',
     default: 0.0,
     nullable: true,
   })

--- a/apps/drec-api/src/pods/device-group/device-group.entity.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.entity.ts
@@ -18,7 +18,6 @@ import {
   StandardCompliance,
 } from '../../utils/enums';
 import { Device } from '../device';
-import { Organization } from '../organization/organization.entity';
 
 @Entity()
 export class DeviceGroup extends ExtendedBaseEntity implements IDeviceGroup {
@@ -87,6 +86,17 @@ export class DeviceGroup extends ExtendedBaseEntity implements IDeviceGroup {
   @Column({ nullable: true })
   @IsString()
   buyerAddress: string;
+
+  @Column({
+    type: 'decimal',
+    precision: 10,
+    scale: 2,
+    default: 0.0,
+    nullable: true,
+  })
+  @IsOptional()
+  @IsNumber()
+  leftoverReads: number;
 
   devices?: Device[];
   organization?: Pick<IFullOrganization, 'name'>;

--- a/apps/drec-api/src/pods/device-group/device-group.service.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.service.ts
@@ -249,6 +249,16 @@ export class DeviceGroupService {
     return updatedGroup;
   }
 
+  async updateLeftOverRead(
+    id: number,
+    leftOverRead: number,
+  ): Promise<DeviceGroupDTO> {
+    const deviceGroup = await this.findById(id);
+    deviceGroup.leftoverReads = leftOverRead;
+    const updatedGroup = await this.repository.save(deviceGroup);
+    return updatedGroup;
+  }
+
   async remove(id: number, organizationId: number): Promise<void> {
     const deviceGroup = await this.findDeviceGroupById(id, organizationId);
 

--- a/apps/drec-api/src/pods/device-group/device-group.service.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.service.ts
@@ -38,7 +38,6 @@ import { groupByProps } from '../../utils/group-by-properties';
 import { getCapacityRange } from '../../utils/get-capacity-range';
 import { getDateRangeFromYear } from '../../utils/get-commissioning-date-range';
 import cleanDeep from 'clean-deep';
-import { getCodeFromCountry } from '../../utils/getCodeFromCountry';
 import { OrganizationService } from '../organization/organization.service';
 
 @Injectable()

--- a/apps/drec-api/src/pods/device-group/dto/device-group.dto.ts
+++ b/apps/drec-api/src/pods/device-group/dto/device-group.dto.ts
@@ -122,6 +122,11 @@ export class DeviceGroupDTO implements IDeviceGroup {
   buyerId: number;
 
   @IsOptional()
+  @ApiPropertyOptional({ type: Number })
+  @IsNumber()
+  leftoverReads: number;
+
+  @IsOptional()
   @ApiPropertyOptional({ type: String })
   @IsString()
   buyerAddress: string;

--- a/apps/drec-api/src/pods/issuer/issuer.service.ts
+++ b/apps/drec-api/src/pods/issuer/issuer.service.ts
@@ -16,7 +16,7 @@ import { BASE_READ_SERVICE } from '../reads/const';
 import { OrganizationService } from '../organization/organization.service';
 import { DeviceGroupService } from '../device-group/device-group.service';
 import { IDevice } from '../../models';
-import { DeviceGroupDTO } from '../device-group/dto';
+import { DeviceGroup } from '../device-group/device-group.entity';
 
 @Injectable()
 export class IssuerService {
@@ -44,7 +44,7 @@ export class IssuerService {
 
     const groups = await this.groupService.getAll();
     await Promise.all(
-      groups.map(async (group: DeviceGroupDTO) => {
+      groups.map(async (group: DeviceGroup) => {
         group.devices = await this.deviceService.findForGroup(group.id);
         return await this.issueCertificateForGroup(group, startDate, endDate);
       }),
@@ -52,7 +52,7 @@ export class IssuerService {
   }
 
   private async issueCertificateForGroup(
-    group: DeviceGroupDTO,
+    group: DeviceGroup,
     startDate: DateTime,
     endDate: DateTime,
   ): Promise<void> {
@@ -87,8 +87,15 @@ export class IssuerService {
       return;
     }
 
-    // Convert from W to kW
-    const totalReadValueKw = Math.round(totalReadValue * 10 ** -3);
+    const totalReadValueKw = await this.handleLeftoverReads(
+      group,
+      +totalReadValue,
+    );
+
+    if (!totalReadValueKw) {
+      return;
+    }
+
     const deviceGroup = {
       ...group,
       devices: [],
@@ -110,6 +117,37 @@ export class IssuerService {
       `Issuance: ${JSON.stringify(issuance)}, Group name: ${group.name}`,
     );
     return await this.issueCertificate(issuance);
+  }
+
+  private async handleLeftoverReads(
+    group: DeviceGroup,
+    totalReadValueW: number,
+  ): Promise<number> {
+    // Logic
+    // 1. Get the accummulated read values from devices
+    // 2. Transform current value from watts to kw
+    // 3. Add any leftover value from group to the current total value
+    // 4. Separate all decimal values from the curent kw value and store it as leftover value to the device group
+    // 5. Return all the integer value from the current kw value (if any) and continue issuing the certificate
+
+    const totalReadValueKw = group.leftoverReads
+      ? totalReadValueW * 10 ** -3 + Number(group.leftoverReads)
+      : totalReadValueW * 10 ** -3;
+    const integerReadValueKw = Math.floor(totalReadValueKw);
+    const leftOverReadValueKw = this.roundDecimalNumber(
+      totalReadValueKw - integerReadValueKw,
+    );
+    await this.groupService.updateLeftOverRead(group.id, leftOverReadValueKw);
+
+    return integerReadValueKw;
+  }
+
+  private roundDecimalNumber(num: number): number {
+    if (num === 0) {
+      return num;
+    }
+    const m = Number((Math.abs(num) * 100).toPrecision(15));
+    return (Math.round(m) / 100) * Math.sign(num);
   }
 
   private async getDeviceFullReads(

--- a/apps/drec-api/src/pods/issuer/issuer.service.ts
+++ b/apps/drec-api/src/pods/issuer/issuer.service.ts
@@ -131,8 +131,8 @@ export class IssuerService {
     // 5. Return all the integer value from the current kw value (if any) and continue issuing the certificate
 
     const totalReadValueKw = group.leftoverReads
-      ? totalReadValueW / 10 ** 3 + Number(group.leftoverReads)
-      : totalReadValueW / 10 ** -3;
+      ? totalReadValueW / 10 ** 3 + group.leftoverReads
+      : totalReadValueW / 10 ** 3;
     const { integralVal, decimalVal } =
       this.separateIntegerAndDecimal(totalReadValueKw);
     await this.groupService.updateLeftOverRead(group.id, decimalVal);
@@ -157,7 +157,7 @@ export class IssuerService {
       return num;
     }
     const precision = 2;
-    return Math.round(1.15 * 10 ** precision) / 10 ** precision;
+    return Math.round(num * 10 ** precision) / 10 ** precision;
   }
 
   private async getDeviceFullReads(

--- a/apps/drec-api/src/pods/issuer/issuer.service.ts
+++ b/apps/drec-api/src/pods/issuer/issuer.service.ts
@@ -89,7 +89,7 @@ export class IssuerService {
 
     const totalReadValueKw = await this.handleLeftoverReads(
       group,
-      +totalReadValue,
+      totalReadValue,
     );
 
     if (!totalReadValueKw) {

--- a/apps/drec-api/src/pods/issuer/issuer.service.ts
+++ b/apps/drec-api/src/pods/issuer/issuer.service.ts
@@ -156,8 +156,8 @@ export class IssuerService {
     if (num === 0) {
       return num;
     }
-    const m = Number((Math.abs(num) * 100).toPrecision(15));
-    return (Math.round(m) / 100) * Math.sign(num);
+    const precision = 2;
+    return Math.round(1.15 * 10 ** precision) / 10 ** precision;
   }
 
   private async getDeviceFullReads(

--- a/apps/drec-api/src/pods/issuer/issuer.service.ts
+++ b/apps/drec-api/src/pods/issuer/issuer.service.ts
@@ -131,15 +131,25 @@ export class IssuerService {
     // 5. Return all the integer value from the current kw value (if any) and continue issuing the certificate
 
     const totalReadValueKw = group.leftoverReads
-      ? totalReadValueW * 10 ** -3 + Number(group.leftoverReads)
-      : totalReadValueW * 10 ** -3;
-    const integerReadValueKw = Math.floor(totalReadValueKw);
-    const leftOverReadValueKw = this.roundDecimalNumber(
-      totalReadValueKw - integerReadValueKw,
-    );
-    await this.groupService.updateLeftOverRead(group.id, leftOverReadValueKw);
+      ? totalReadValueW / 10 ** 3 + Number(group.leftoverReads)
+      : totalReadValueW / 10 ** -3;
+    const { integralVal, decimalVal } =
+      this.separateIntegerAndDecimal(totalReadValueKw);
+    await this.groupService.updateLeftOverRead(group.id, decimalVal);
 
-    return integerReadValueKw;
+    return integralVal;
+  }
+
+  private separateIntegerAndDecimal(num: number): {
+    integralVal: number;
+    decimalVal: number;
+  } {
+    if (!num) {
+      return { integralVal: 0, decimalVal: 0 };
+    }
+    const integralVal = Math.floor(num);
+    const decimalVal = this.roundDecimalNumber(num - integralVal);
+    return { integralVal, decimalVal };
   }
 
   private roundDecimalNumber(num: number): number {


### PR DESCRIPTION
If we have reads which have decimal value ex: 1.7 Kw or 0.7 kw, we need to issue only integer value and keep leftover values to the next issuance day (0.7 is leftover).

Logic
  1. Get the accummulated read values from devices from a group
  2. Transform current value from watts to kw
  3. Add any leftover value from group to the current total value
  4. Separate all decimal values from the curent kw value and store it as leftover value to the device group
  5. Return the integer value from the current kw value (if any) and continue issuing the certificate
  6. If no value, then don`t issue the certificate