### PR TITLE
Feature/unreserve group

### DIFF
--- a/apps/drec-api/migrations/1636639831399-DeviceGroupBuyerId.ts
+++ b/apps/drec-api/migrations/1636639831399-DeviceGroupBuyerId.ts
@@ -11,7 +11,10 @@ export class DeviceGroupBuyerId1636639831399 implements MigrationInterface {
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `ALTER TABLE "device_group" ALTER COLUMN "buyerAddress" character varying`,
+      `ALTER TABLE "device_group" DROP COLUMN "buyerAddress"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "device_group" ADD "buyerAddress" character varying`,
     );
   }
 }

--- a/apps/drec-api/migrations/1636639831399-DeviceGroupBuyerId.ts
+++ b/apps/drec-api/migrations/1636639831399-DeviceGroupBuyerId.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class DeviceGroupBuyerId1636639831399 implements MigrationInterface {
+  name = 'DeviceGroupBuyerId1636639831399';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "device_group" DROP COLUMN "buyerAddress"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "device_group" ADD "buyerAddress" text`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "device_group" DROP COLUMN "buyerAddress"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "device_group" ADD "buyerAddress" character varying`,
+    );
+  }
+}

--- a/apps/drec-api/migrations/1636639831399-DeviceGroupBuyerId.ts
+++ b/apps/drec-api/migrations/1636639831399-DeviceGroupBuyerId.ts
@@ -5,19 +5,13 @@ export class DeviceGroupBuyerId1636639831399 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `ALTER TABLE "device_group" DROP COLUMN "buyerAddress"`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "device_group" ADD "buyerAddress" text`,
+      `ALTER TABLE "device_group" ALTER COLUMN "buyerAddress" TYPE text`,
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `ALTER TABLE "device_group" DROP COLUMN "buyerAddress"`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "device_group" ADD "buyerAddress" character varying`,
+      `ALTER TABLE "device_group" ALTER COLUMN "buyerAddress" character varying`,
     );
   }
 }

--- a/apps/drec-api/src/models/DeviceGroup.ts
+++ b/apps/drec-api/src/models/DeviceGroup.ts
@@ -36,6 +36,6 @@ export interface IDeviceGroup {
   devices?: DeviceDTO[];
   organization?: Pick<OrganizationDTO, 'name'>;
 
-  buyerId?: number;
-  buyerAddress?: string;
+  buyerId?: number | null;
+  buyerAddress?: string | null;
 }

--- a/apps/drec-api/src/pods/device-group/device-group.controller.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.controller.ts
@@ -68,6 +68,23 @@ export class DeviceGroupController {
     return this.deviceGroupService.getUnreserved(filterDto);
   }
 
+  @Get('/reserved')
+  @UseGuards(AuthGuard('jwt'), RolesGuard)
+  @Roles(Role.Admin, Role.Buyer)
+  @ApiOkResponse({
+    type: [DeviceGroupDTO],
+    description: 'Returns all reserved Device Groups',
+  })
+  async getReserved(
+    @UserDecorator() { id, blockchainAccountAddress }: ILoggedInUser,
+    @Query(ValidationPipe) filterDto: UnreservedDeviceGroupsFilterDTO,
+  ): Promise<DeviceGroupDTO[]> {
+    return this.deviceGroupService.getReserved(filterDto, {
+      id,
+      blockchainAccountAddress,
+    });
+  }
+
   @Get('/my')
   @UseGuards(AuthGuard('jwt'), RolesGuard)
   @Roles(Role.OrganizationAdmin, Role.DeviceOwner, Role.OrganizationUser)
@@ -126,6 +143,25 @@ export class DeviceGroupController {
     @Body() ids: ReserveGroupsDTO,
   ): Promise<DeviceGroupDTO[]> {
     return await this.deviceGroupService.reserveGroup(
+      ids,
+      organizationId,
+      blockchainAccountAddress,
+    );
+  }
+
+  @Post('/unreserve')
+  @UseGuards(AuthGuard('jwt'), RolesGuard)
+  @Roles(Role.Buyer)
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Unreserves device groups from buyer',
+  })
+  public async unreserve(
+    @UserDecorator()
+    { organizationId, blockchainAccountAddress }: ILoggedInUser,
+    @Body() ids: ReserveGroupsDTO,
+  ): Promise<void> {
+    return await this.deviceGroupService.unreserveGroup(
       ids,
       organizationId,
       blockchainAccountAddress,

--- a/apps/drec-api/src/pods/device-group/device-group.entity.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.entity.ts
@@ -79,13 +79,13 @@ export class DeviceGroup extends ExtendedBaseEntity implements IDeviceGroup {
   @IsOptional()
   labels: string[];
 
-  @Column({ nullable: true })
+  @Column({ type: 'int', nullable: true })
   @IsNumber()
-  buyerId: number;
+  buyerId!: number | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'text', nullable: true })
   @IsString()
-  buyerAddress: string;
+  buyerAddress!: string | null;
 
   @Column({
     type: 'float',

--- a/apps/drec-api/src/pods/device-group/dto/device-group.dto.ts
+++ b/apps/drec-api/src/pods/device-group/dto/device-group.dto.ts
@@ -119,15 +119,15 @@ export class DeviceGroupDTO implements IDeviceGroup {
   @IsOptional()
   @ApiPropertyOptional({ type: Number })
   @IsNumber()
-  buyerId: number;
+  buyerId!: number | null;
+
+  @IsOptional()
+  @ApiPropertyOptional({ type: String })
+  @IsString()
+  buyerAddress!: string | null;
 
   @IsOptional()
   @ApiPropertyOptional({ type: Number })
   @IsNumber()
   leftoverReads: number;
-
-  @IsOptional()
-  @ApiPropertyOptional({ type: String })
-  @IsString()
-  buyerAddress: string;
 }

--- a/apps/drec-api/src/pods/device-group/dto/index.ts
+++ b/apps/drec-api/src/pods/device-group/dto/index.ts
@@ -5,5 +5,5 @@ export * from './device-id.dto';
 export * from './update-device.dto';
 export * from './add-device-group.dto';
 export * from './unreserved-filter.dto';
-export * from './unreserved-device-group.dto';
+export * from './selectable-device-group.dto';
 export * from './reserve-groups.dto';

--- a/apps/drec-api/src/pods/device-group/dto/selectable-device-group.dto.ts
+++ b/apps/drec-api/src/pods/device-group/dto/selectable-device-group.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsBoolean } from 'class-validator';
 import { DeviceGroupDTO } from './device-group.dto';
 
-export class UnreservedDeviceGroupDTO extends DeviceGroupDTO {
+export class SelectableDeviceGroupDTO extends DeviceGroupDTO {
   @ApiProperty()
   @IsBoolean()
   selected: boolean;

--- a/apps/drec-api/test/device.e2e-spec.ts
+++ b/apps/drec-api/test/device.e2e-spec.ts
@@ -213,7 +213,7 @@ describe('Device tests', () => {
       HttpStatus.OK,
       orderFilter,
     );
-    console.log('Device groups: ', deviceGroups[0].devices);
+
     expect(deviceGroups).to.be.instanceOf(Array);
     expect(deviceGroups[0].devices[0].offTaker).to.eq(OffTaker.HealthFacility);
     expect(deviceGroups[0].devices[0].sector).to.eq(Sector.Agriculture);

--- a/apps/drec-ui/src/apps/device-group/data/allReservedDeviceGroups.ts
+++ b/apps/drec-ui/src/apps/device-group/data/allReservedDeviceGroups.ts
@@ -1,0 +1,25 @@
+import {
+    DeviceGroupControllerGetUnreservedParams,
+    useDeviceGroupControllerGetReserved
+} from '@energyweb/origin-drec-api-client';
+import { UnreservedFormFormValues } from '../logic';
+import cleanDeep from 'clean-deep';
+
+export const useReservedDeviceGroups = (values: UnreservedFormFormValues) => {
+    const params = formatFormValuesToFilterParams(values);
+    const { data: deviceGroups, isLoading } = useDeviceGroupControllerGetReserved(params);
+    return { deviceGroups, isLoading };
+};
+
+const formatFormValuesToFilterParams = (values: UnreservedFormFormValues) => {
+    return cleanDeep({
+        ...values,
+        country: values.country && values.country.length ? values.country[0].value : null,
+        fuelCode: values.fuelCode && values.fuelCode.length ? values.fuelCode[0].value : null,
+        gridInterconnection: values.gridInterconnection
+            ? values.gridInterconnection === 'No'
+                ? false
+                : true
+            : null
+    } as DeviceGroupControllerGetUnreservedParams);
+};

--- a/apps/drec-ui/src/apps/device-group/data/autoSelectGroups.ts
+++ b/apps/drec-ui/src/apps/device-group/data/autoSelectGroups.ts
@@ -34,7 +34,7 @@ export const useAutoSelectedGroups = (
                 },
                 onError: (error: any) => {
                     showNotification(
-                        `Error while updating user:
+                        `Error while creating device groups:
                             ${error?.response?.data?.message || ''}
                             `,
                         NotificationTypeEnum.Error

--- a/apps/drec-ui/src/apps/device-group/data/createNewGroup.ts
+++ b/apps/drec-ui/src/apps/device-group/data/createNewGroup.ts
@@ -37,7 +37,7 @@ export const useCreateNewGroup = (group: GroupedDevicesDTO, handleModalClose: ()
                 },
                 onError: (error: any) => {
                     showNotification(
-                        `Error while updating user:
+                        `Error while creating device group:
                             ${error?.response?.data?.message || ''}
                             `,
                         NotificationTypeEnum.Error

--- a/apps/drec-ui/src/apps/device-group/data/index.ts
+++ b/apps/drec-ui/src/apps/device-group/data/index.ts
@@ -9,3 +9,5 @@ export * from './createNewGroup';
 export * from './autoSelectGroups';
 export * from './allUnreservedDeviceGroups';
 export * from './reserveSelectedGroups';
+export * from './allReservedDeviceGroups';
+export * from './unreserveSelectedGroups';

--- a/apps/drec-ui/src/apps/device-group/data/unreserveSelectedGroups.ts
+++ b/apps/drec-ui/src/apps/device-group/data/unreserveSelectedGroups.ts
@@ -1,19 +1,19 @@
 import {
     SelectableDeviceGroupDTO,
-    getDeviceGroupControllerGetUnreservedQueryKey,
-    useDeviceGroupControllerReserve,
+    getDeviceGroupControllerGetReservedQueryKey,
+    useDeviceGroupControllerUnreserve,
     ReserveGroupsDTO
 } from '@energyweb/origin-drec-api-client';
 import { useQueryClient } from 'react-query';
 import { NotificationTypeEnum, showNotification } from '@energyweb/origin-ui-core';
 
-export const useReserveSelectedGroups = (
+export const useUnreserveSelectedGroups = (
     selected: SelectableDeviceGroupDTO[],
     handleModalClose: () => void
 ) => {
-    const { mutate } = useDeviceGroupControllerReserve();
+    const { mutate } = useDeviceGroupControllerUnreserve();
     const queryClient = useQueryClient();
-    const currentUnreservedDeviceGroupsQueryKey = getDeviceGroupControllerGetUnreservedQueryKey();
+    const currentReservedDeviceGroupsQueryKey = getDeviceGroupControllerGetReservedQueryKey();
 
     const reserveGroupsHandler = () => {
         const data: ReserveGroupsDTO = {
@@ -23,16 +23,16 @@ export const useReserveSelectedGroups = (
             { data },
             {
                 onSuccess: () => {
-                    queryClient.resetQueries(currentUnreservedDeviceGroupsQueryKey);
+                    queryClient.resetQueries(currentReservedDeviceGroupsQueryKey);
                     showNotification(
-                        'Device groups successfully reserved',
+                        'Device groups successfully unreserved',
                         NotificationTypeEnum.Success
                     );
                     handleModalClose();
                 },
                 onError: (error: any) => {
                     showNotification(
-                        `Error while reserving device groups:
+                        `Error while unreserving device groups:
                             ${error?.response?.data?.message || ''}
                             `,
                         NotificationTypeEnum.Error

--- a/apps/drec-ui/src/apps/device-group/logic/form/deviceGroupsFilterForm.ts
+++ b/apps/drec-ui/src/apps/device-group/logic/form/deviceGroupsFilterForm.ts
@@ -30,7 +30,7 @@ type TUnreservedFormFormLogic = (
     allFuelTypes: CodeNameDTO[]
 ) => Omit<GenericFormProps<UnreservedFormFormValues>, 'submitHandler'>;
 
-export const useUnreservedFilterFormLogic: TUnreservedFormFormLogic = (
+export const useDeviceGroupsFilterFormLogic: TUnreservedFormFormLogic = (
     initialValues: UnreservedFormFormValues,
     allFuelTypes: CodeNameDTO[]
 ) => {

--- a/apps/drec-ui/src/apps/device-group/logic/form/deviceGroupsFilterForm.ts
+++ b/apps/drec-ui/src/apps/device-group/logic/form/deviceGroupsFilterForm.ts
@@ -27,15 +27,17 @@ export type UnreservedFormFormValues = {
 
 type TUnreservedFormFormLogic = (
     initialValues: UnreservedFormFormValues,
-    allFuelTypes: CodeNameDTO[]
+    allFuelTypes: CodeNameDTO[],
+    isMutating: boolean
 ) => Omit<GenericFormProps<UnreservedFormFormValues>, 'submitHandler'>;
 
 export const useDeviceGroupsFilterFormLogic: TUnreservedFormFormLogic = (
     initialValues: UnreservedFormFormValues,
-    allFuelTypes: CodeNameDTO[]
+    allFuelTypes: CodeNameDTO[],
+    isMutating: boolean
 ) => {
     const gridInterconnectionOptions: FormSelectOption[] = [
-        { value: '', label: '- Clear -' },
+        { value: '', label: 'Any' },
         { value: 'Yes', label: 'Yes' },
         { value: 'No', label: 'No' }
     ];
@@ -113,7 +115,7 @@ export const useDeviceGroupsFilterFormLogic: TUnreservedFormFormLogic = (
         validationMode: 'onSubmit',
         inputsVariant: 'filled',
         buttonText: 'Filter',
-        buttonDisabled: false,
+        buttonDisabled: isMutating,
         acceptInitialValues: true
     };
 };

--- a/apps/drec-ui/src/apps/device-group/logic/form/index.ts
+++ b/apps/drec-ui/src/apps/device-group/logic/form/index.ts
@@ -1,2 +1,2 @@
-export * from './unreservedFilterForm';
+export * from './deviceGroupsFilterForm';
 export * from './createNewGroupFormLogic';

--- a/apps/drec-ui/src/apps/device-group/logic/menu/getDeviceGroupMenu.ts
+++ b/apps/drec-ui/src/apps/device-group/logic/menu/getDeviceGroupMenu.ts
@@ -7,6 +7,7 @@ export type TGetDeviceGroupMenuArgs = {
     showMyDeviceGroups: boolean;
     showUngroupedDevices: boolean;
     showUnreserved: boolean;
+    showReserved: boolean;
     menuButtonClass?: string;
     selectedMenuItemClass?: string;
 };
@@ -20,6 +21,7 @@ export const getDeviceGroupMenu: TGetDeviceGroupMenu = ({
     showMyDeviceGroups,
     showUngroupedDevices,
     showUnreserved,
+    showReserved,
     selectedMenuItemClass,
     menuButtonClass
 }) => {
@@ -43,6 +45,11 @@ export const getDeviceGroupMenu: TGetDeviceGroupMenu = ({
             url: 'unreserved',
             label: 'Unreserved Device Groups',
             show: showUnreserved
+        },
+        {
+            url: 'reserved',
+            label: 'Reserved Device Groups',
+            show: showReserved
         }
     ];
 

--- a/apps/drec-ui/src/apps/device-group/logic/modals/index.ts
+++ b/apps/drec-ui/src/apps/device-group/logic/modals/index.ts
@@ -1,3 +1,4 @@
 export * from './deleteDeviceGroup';
 export * from './autoGroup';
 export * from './reserveSelected';
+export * from './unreserveSelected';

--- a/apps/drec-ui/src/apps/device-group/logic/modals/unreserveSelected.ts
+++ b/apps/drec-ui/src/apps/device-group/logic/modals/unreserveSelected.ts
@@ -1,0 +1,15 @@
+export const useUnreserveSelectedModalLogic = (closeModal: () => void, unreserve: () => void) => {
+    return {
+        text: 'Unreserve all the selected device groups?',
+        buttons: [
+            {
+                label: 'Cancel',
+                onClick: closeModal
+            },
+            {
+                label: 'Uneserve',
+                onClick: unreserve
+            }
+        ]
+    };
+};

--- a/apps/drec-ui/src/apps/device-group/logic/table/index.ts
+++ b/apps/drec-ui/src/apps/device-group/logic/table/index.ts
@@ -1,3 +1,3 @@
 export * from './useDevicesTableLogic';
 export * from './useUngroupedDevicesTableLogic';
-export * from './useUnreservedDeviceGroupsTableLogic';
+export * from './useSelectableDeviceGroupsTableLogic';

--- a/apps/drec-ui/src/apps/device-group/logic/table/useSelectableDeviceGroupsTableLogic.tsx
+++ b/apps/drec-ui/src/apps/device-group/logic/table/useSelectableDeviceGroupsTableLogic.tsx
@@ -1,12 +1,12 @@
-import { CodeNameDTO, UnreservedDeviceGroupDTO } from '@energyweb/origin-drec-api-client';
+import { CodeNameDTO, SelectableDeviceGroupDTO } from '@energyweb/origin-drec-api-client';
 import { TableComponentProps } from '@energyweb/origin-ui-core';
 import { Checkbox } from '@material-ui/core';
 import { getFuelNameFromCode } from '../../../../utils';
 
-const prepareUnreservedDeviceGroupsData = (
-    group: UnreservedDeviceGroupDTO,
+const prepareSelectableDeviceGroupsData = (
+    group: SelectableDeviceGroupDTO,
     allFuelTypes: CodeNameDTO[],
-    handleChecked: (id: UnreservedDeviceGroupDTO['id'], checked: boolean) => void
+    handleChecked: (id: SelectableDeviceGroupDTO['id'], checked: boolean) => void
 ) => ({
     id: group.id,
     country: group.countryCode,
@@ -28,12 +28,12 @@ const prepareUnreservedDeviceGroupsData = (
     )
 });
 
-export const useUnreservedDeviceGroupsTableLogic = (
-    groups: UnreservedDeviceGroupDTO[],
-    handleChecked: (id: UnreservedDeviceGroupDTO['id'], checked: boolean) => void,
+export const useSelectableDeviceGroupsTableLogic = (
+    groups: SelectableDeviceGroupDTO[],
+    handleChecked: (id: SelectableDeviceGroupDTO['id'], checked: boolean) => void,
     loading: boolean,
     allFuelTypes: CodeNameDTO[]
-): TableComponentProps<UnreservedDeviceGroupDTO['id']> => {
+): TableComponentProps<SelectableDeviceGroupDTO['id']> => {
     return {
         header: {
             country: 'Country',
@@ -51,7 +51,7 @@ export const useUnreservedDeviceGroupsTableLogic = (
         pageSize: 25,
         data:
             groups?.map((group) =>
-                prepareUnreservedDeviceGroupsData(group, allFuelTypes, handleChecked)
+                prepareSelectableDeviceGroupsData(group, allFuelTypes, handleChecked)
             ) ?? []
     };
 };

--- a/apps/drec-ui/src/apps/device-group/view/DeviceGroupApp.tsx
+++ b/apps/drec-ui/src/apps/device-group/view/DeviceGroupApp.tsx
@@ -6,7 +6,8 @@ import {
     MyDeviceGroupsPage,
     DetailViewGroupPage,
     UngroupedDevicesPage,
-    UnreservedPage
+    UnreservedPage,
+    ReservedPage
 } from './pages';
 import {
     DeviceGroupAppEnvProvider,
@@ -21,13 +22,19 @@ export interface DeviceGroupAppProps {
         showMyDeviceGroups: boolean;
         showUngroupedDevices: boolean;
         showUnreserved: boolean;
+        showReserved: boolean;
     };
     envVariables: DeviceGroupEnvVariables;
 }
 
 export const DeviceGroupApp: FC<DeviceGroupAppProps> = ({ routesConfig, envVariables }) => {
-    const { showAllDeviceGroups, showMyDeviceGroups, showUngroupedDevices, showUnreserved } =
-        routesConfig;
+    const {
+        showAllDeviceGroups,
+        showMyDeviceGroups,
+        showUngroupedDevices,
+        showUnreserved,
+        showReserved
+    } = routesConfig;
     return (
         <DeviceGroupAppEnvProvider variables={envVariables}>
             <DeviceGroupModalsProvider>
@@ -38,6 +45,7 @@ export const DeviceGroupApp: FC<DeviceGroupAppProps> = ({ routesConfig, envVaria
                         <Route path="ungrouped" element={<UngroupedDevicesPage />} />
                     )}
                     {showUnreserved && <Route path="unreserved" element={<UnreservedPage />} />}
+                    {showReserved && <Route path="reserved" element={<ReservedPage />} />}
                     {showAllDeviceGroups && (
                         <Route path="detail-view/:id" element={<DetailViewGroupPage />} />
                     )}

--- a/apps/drec-ui/src/apps/device-group/view/containers/modals/DeviceGroupModalsCenter.tsx
+++ b/apps/drec-ui/src/apps/device-group/view/containers/modals/DeviceGroupModalsCenter.tsx
@@ -3,6 +3,7 @@ import { AutoGroupSelected } from './AutoGroupSelected';
 import { CreateNewGroup } from './CreateNewGroup';
 import { DeleteDeviceGroup } from './DeleteDeviceGroup';
 import { ReserveSelected } from './ReserveSelected';
+import { UnreserveSelected } from './UnreserveSelected';
 
 export const DeviceGroupModalsCenter: FC = () => {
     return (
@@ -11,6 +12,7 @@ export const DeviceGroupModalsCenter: FC = () => {
             <CreateNewGroup />
             <AutoGroupSelected />
             <ReserveSelected />
+            <UnreserveSelected />
         </>
     );
 };

--- a/apps/drec-ui/src/apps/device-group/view/containers/modals/ReserveSelected/ReserveSelected.effects.ts
+++ b/apps/drec-ui/src/apps/device-group/view/containers/modals/ReserveSelected/ReserveSelected.effects.ts
@@ -26,11 +26,8 @@ export const useReserveSelectedEffects = () => {
     const reserveSelectedHandler = useReserveSelectedGroups(selected, closeModal);
 
     const reserveHandler = () => {
-        dispatchModals({
-            type: DeviceGroupModalsActionsEnum.RESERVE,
-            payload: { open: false, selected: [] }
-        });
         reserveSelectedHandler();
+        closeModal();
     };
 
     const { text, buttons } = useReserveSelectedModalLogic(closeModal, reserveHandler);

--- a/apps/drec-ui/src/apps/device-group/view/containers/modals/UnreserveSelected/UnreserveSelected.effects.ts
+++ b/apps/drec-ui/src/apps/device-group/view/containers/modals/UnreserveSelected/UnreserveSelected.effects.ts
@@ -1,0 +1,43 @@
+import { GenericModalProps } from '@energyweb/origin-ui-core';
+import { useUnreserveSelectedGroups } from '../../../../data';
+import { useUnreserveSelectedModalLogic } from '../../../../logic';
+import {
+    useDeviceGroupModalsStore,
+    useDeviceGroupModalsDispatch,
+    DeviceGroupModalsActionsEnum
+} from '../../../context';
+
+export const useUnreserveSelectedEffects = () => {
+    const {
+        unreserveSelected: { open, selected }
+    } = useDeviceGroupModalsStore();
+    const dispatchModals = useDeviceGroupModalsDispatch();
+
+    const closeModal = () => {
+        dispatchModals({
+            type: DeviceGroupModalsActionsEnum.UNRESERVE,
+            payload: {
+                open: false,
+                selected: []
+            }
+        });
+    };
+
+    const unreserveSelectedHandler = useUnreserveSelectedGroups(selected, closeModal);
+
+    const unreserveHandler = () => {
+        dispatchModals({
+            type: DeviceGroupModalsActionsEnum.UNRESERVE,
+            payload: { open: false, selected: [] }
+        });
+        unreserveSelectedHandler();
+    };
+
+    const { text, buttons } = useUnreserveSelectedModalLogic(closeModal, unreserveHandler);
+
+    const dialogProps: GenericModalProps['dialogProps'] = {
+        maxWidth: 'sm'
+    };
+
+    return { open, text, buttons, dialogProps };
+};

--- a/apps/drec-ui/src/apps/device-group/view/containers/modals/UnreserveSelected/UnreserveSelected.effects.ts
+++ b/apps/drec-ui/src/apps/device-group/view/containers/modals/UnreserveSelected/UnreserveSelected.effects.ts
@@ -26,11 +26,8 @@ export const useUnreserveSelectedEffects = () => {
     const unreserveSelectedHandler = useUnreserveSelectedGroups(selected, closeModal);
 
     const unreserveHandler = () => {
-        dispatchModals({
-            type: DeviceGroupModalsActionsEnum.UNRESERVE,
-            payload: { open: false, selected: [] }
-        });
         unreserveSelectedHandler();
+        closeModal();
     };
 
     const { text, buttons } = useUnreserveSelectedModalLogic(closeModal, unreserveHandler);

--- a/apps/drec-ui/src/apps/device-group/view/containers/modals/UnreserveSelected/UnreserveSelected.tsx
+++ b/apps/drec-ui/src/apps/device-group/view/containers/modals/UnreserveSelected/UnreserveSelected.tsx
@@ -1,0 +1,9 @@
+import { GenericModal } from '@energyweb/origin-ui-core';
+import { FC } from 'react';
+import { useUnreserveSelectedEffects } from './UnreserveSelected.effects';
+
+export const UnreserveSelected: FC = () => {
+    const { open, text, buttons, dialogProps } = useUnreserveSelectedEffects();
+
+    return <GenericModal open={open} text={text} buttons={buttons} dialogProps={dialogProps} />;
+};

--- a/apps/drec-ui/src/apps/device-group/view/containers/modals/UnreserveSelected/index.ts
+++ b/apps/drec-ui/src/apps/device-group/view/containers/modals/UnreserveSelected/index.ts
@@ -1,0 +1,1 @@
+export * from './UnreserveSelected';

--- a/apps/drec-ui/src/apps/device-group/view/containers/modals/index.ts
+++ b/apps/drec-ui/src/apps/device-group/view/containers/modals/index.ts
@@ -3,3 +3,4 @@ export * from './CreateNewGroup';
 export * from './AutoGroupSelected';
 export * from './ReserveSelected';
 export * from './DeviceGroupModalsCenter';
+export * from './UnreserveSelected';

--- a/apps/drec-ui/src/apps/device-group/view/context/modals/reducer.ts
+++ b/apps/drec-ui/src/apps/device-group/view/context/modals/reducer.ts
@@ -4,7 +4,8 @@ export enum DeviceGroupModalsActionsEnum {
     SHOW_DELETE_GROUP = 'SHOW_DELETE_GROUP',
     AUTO_GROUP_SELECTED = 'AUTO_GROUP_SELECTED',
     CREATE_NEW_GROUP = 'CREATE_NEW_GROUP',
-    RESERVE = 'RESERVE'
+    RESERVE = 'RESERVE',
+    UNRESERVE = 'UNRESERVE'
 }
 
 export const deviceGroupModalsInitialState: IDeviceGroupModalsStore = {
@@ -24,6 +25,10 @@ export const deviceGroupModalsInitialState: IDeviceGroupModalsStore = {
     reserveSelected: {
         open: false,
         selected: []
+    },
+    unreserveSelected: {
+        open: false,
+        selected: []
     }
 };
 
@@ -40,5 +45,7 @@ export const deviceGroupModalsReducer = (
             return { ...state, createNewGroup: action.payload };
         case DeviceGroupModalsActionsEnum.RESERVE:
             return { ...state, reserveSelected: action.payload };
+        case DeviceGroupModalsActionsEnum.UNRESERVE:
+            return { ...state, unreserveSelected: action.payload };
     }
 };

--- a/apps/drec-ui/src/apps/device-group/view/context/modals/types.ts
+++ b/apps/drec-ui/src/apps/device-group/view/context/modals/types.ts
@@ -1,4 +1,4 @@
-import { GroupedDevicesDTO, UnreservedDeviceGroupDTO } from '@energyweb/origin-drec-api-client';
+import { GroupedDevicesDTO, SelectableDeviceGroupDTO } from '@energyweb/origin-drec-api-client';
 import { DeviceOrderBy } from '../../../../../utils';
 import { DeviceGroupModalsActionsEnum } from './reducer';
 
@@ -13,9 +13,9 @@ export type TCreateNewGroup = {
     group: GroupedDevicesDTO;
 };
 
-export type TReserveSelected = {
+export type TSelectedGroups = {
     open: boolean;
-    selected: UnreservedDeviceGroupDTO[];
+    selected: SelectableDeviceGroupDTO[];
 };
 
 export interface IDeviceGroupModalsStore {
@@ -25,7 +25,8 @@ export interface IDeviceGroupModalsStore {
     };
     autoGroupSelected: TAutoGroupSelected;
     createNewGroup: TCreateNewGroup;
-    reserveSelected: TReserveSelected;
+    reserveSelected: TSelectedGroups;
+    unreserveSelected: TSelectedGroups;
 }
 
 interface IDeviceGroupDeleteAction {
@@ -48,11 +49,17 @@ interface IDeviceGroupCreateNewAction {
 
 interface IDeviceGroupReserveAction {
     type: DeviceGroupModalsActionsEnum.RESERVE;
-    payload: TReserveSelected;
+    payload: TSelectedGroups;
+}
+
+interface IDeviceGroupUnreserveAction {
+    type: DeviceGroupModalsActionsEnum.UNRESERVE;
+    payload: TSelectedGroups;
 }
 
 export type TDeviceGroupModalsAction =
     | IDeviceGroupDeleteAction
     | IDeviceGroupAutoGroupActions
     | IDeviceGroupCreateNewAction
-    | IDeviceGroupReserveAction;
+    | IDeviceGroupReserveAction
+    | IDeviceGroupUnreserveAction;

--- a/apps/drec-ui/src/apps/device-group/view/pages/ReservedPage/ReservedPage.effects.ts
+++ b/apps/drec-ui/src/apps/device-group/view/pages/ReservedPage/ReservedPage.effects.ts
@@ -5,11 +5,11 @@ import {
     useDeviceGroupsFilterFormLogic
 } from '../../../logic';
 import { GenericFormProps } from '@energyweb/origin-ui-core';
-import { useAllDeviceFuelTypes, useUnreservedDeviceGroups } from '../../../data';
+import { useAllDeviceFuelTypes, useReservedDeviceGroups } from '../../../data';
 import { useEffect, useState } from 'react';
 import { SelectableDeviceGroupDTO } from '@energyweb/origin-drec-api-client';
 
-export const useUnreservedPageEffects = () => {
+export const useReservedPageEffects = () => {
     const initialFormValues: UnreservedFormFormValues = {
         country: [],
         fuelCode: [],
@@ -23,7 +23,7 @@ export const useUnreservedPageEffects = () => {
     };
     const [filterUnreserved, setFilterUnreserved] = useState(initialFormValues);
     const { deviceGroups, isLoading: IsLoadingDeviceGroups } =
-        useUnreservedDeviceGroups(filterUnreserved);
+        useReservedDeviceGroups(filterUnreserved);
     const [selectedDeviceGroupList, setSelectedDeviceGroupList] = useState(deviceGroups);
     const dispatchModals = useDeviceGroupModalsDispatch();
 
@@ -66,12 +66,12 @@ export const useUnreservedPageEffects = () => {
         submitHandler
     };
 
-    const onReserveHandler = () => {
+    const onUnreserveHandler = () => {
         const autoSelected: SelectableDeviceGroupDTO[] = selectedDeviceGroupList.filter(
-            (group: SelectableDeviceGroupDTO) => group.selected === true
+            (group: SelectableDeviceGroupDTO) => group.selected === false
         );
         dispatchModals({
-            type: DeviceGroupModalsActionsEnum.RESERVE,
+            type: DeviceGroupModalsActionsEnum.UNRESERVE,
             payload: {
                 open: true,
                 selected: autoSelected
@@ -79,12 +79,12 @@ export const useUnreservedPageEffects = () => {
         });
     };
 
-    const noUnreservedDeviceGroupsTitle =
-        'Currently there aren`t any unreserved device groups for the selection criteria';
+    const noReservedDeviceGroupsTitle =
+        'Currently there aren`t any reserved device groups for the selection criteria';
 
     const disableReserveButton =
         selectedDeviceGroupList?.filter(
-            (group: SelectableDeviceGroupDTO) => group.selected === true
+            (group: SelectableDeviceGroupDTO) => group.selected === false
         ).length === 0;
 
     return {
@@ -92,8 +92,8 @@ export const useUnreservedPageEffects = () => {
         tableProps,
         formData,
         isLoading,
-        noUnreservedDeviceGroupsTitle,
-        onReserveHandler,
+        noReservedDeviceGroupsTitle,
+        onUnreserveHandler,
         disableReserveButton
     };
 };

--- a/apps/drec-ui/src/apps/device-group/view/pages/ReservedPage/ReservedPage.effects.ts
+++ b/apps/drec-ui/src/apps/device-group/view/pages/ReservedPage/ReservedPage.effects.ts
@@ -9,29 +9,31 @@ import { useAllDeviceFuelTypes, useReservedDeviceGroups } from '../../../data';
 import { useEffect, useState } from 'react';
 import { SelectableDeviceGroupDTO } from '@energyweb/origin-drec-api-client';
 
+const initialFormValues: UnreservedFormFormValues = {
+    country: [],
+    fuelCode: [],
+    installationConfiguration: '',
+    offTaker: '',
+    sector: '',
+    standardCompliance: '',
+    gridInterconnection: '',
+    commissioningDateRange: '',
+    capacityRange: ''
+};
+
 export const useReservedPageEffects = () => {
-    const initialFormValues: UnreservedFormFormValues = {
-        country: [],
-        fuelCode: [],
-        installationConfiguration: '',
-        offTaker: '',
-        sector: '',
-        standardCompliance: '',
-        gridInterconnection: '',
-        commissioningDateRange: '',
-        capacityRange: ''
-    };
     const [filterUnreserved, setFilterUnreserved] = useState(initialFormValues);
-    const { deviceGroups, isLoading: IsLoadingDeviceGroups } =
+    const { deviceGroups, isLoading: IsDeviceGroupsMutating } =
         useReservedDeviceGroups(filterUnreserved);
     const [selectedDeviceGroupList, setSelectedDeviceGroupList] = useState(deviceGroups);
     const dispatchModals = useDeviceGroupModalsDispatch();
 
     const { allTypes, isLoading: isDeviceTypesLoading } = useAllDeviceFuelTypes();
 
-    const { fields, initialValues, validationSchema, buttonText } = useDeviceGroupsFilterFormLogic(
-        filterUnreserved,
-        allTypes
+    const formLogic = useDeviceGroupsFilterFormLogic(
+        initialFormValues,
+        allTypes,
+        IsDeviceGroupsMutating
     );
 
     const handleChecked = (id: SelectableDeviceGroupDTO['id'], checked: boolean) => {
@@ -46,7 +48,7 @@ export const useReservedPageEffects = () => {
     const tableProps = useSelectableDeviceGroupsTableLogic(
         deviceGroups,
         handleChecked,
-        IsLoadingDeviceGroups,
+        IsDeviceGroupsMutating,
         allTypes
     );
 
@@ -57,12 +59,9 @@ export const useReservedPageEffects = () => {
     const submitHandler = (values: UnreservedFormFormValues) => {
         setFilterUnreserved(values);
     };
-    const isLoading = IsLoadingDeviceGroups || isDeviceTypesLoading;
+    const isLoading = isDeviceTypesLoading;
     const formData: GenericFormProps<UnreservedFormFormValues> = {
-        fields,
-        initialValues,
-        validationSchema,
-        buttonText,
+        ...formLogic,
         submitHandler
     };
 

--- a/apps/drec-ui/src/apps/device-group/view/pages/ReservedPage/ReservedPage.styles.ts
+++ b/apps/drec-ui/src/apps/device-group/view/pages/ReservedPage/ReservedPage.styles.ts
@@ -1,0 +1,28 @@
+import { makeStyles } from '@material-ui/styles';
+
+export const useStyles = makeStyles(() => ({
+    paper: {
+        width: '100%',
+        marginBottom: 20,
+        padding: '20px'
+    },
+    dataWrapper: {
+        width: '100%',
+        padding: 20
+    },
+    devicesWrapper: {
+        marginTop: 20,
+        width: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'start',
+        alignItems: 'start',
+        gap: 20
+    },
+    buttonsWrapper: {
+        width: '100%',
+        display: 'flex',
+        justifyContent: 'end',
+        marginTop: 20
+    }
+}));

--- a/apps/drec-ui/src/apps/device-group/view/pages/ReservedPage/ReservedPage.styles.ts
+++ b/apps/drec-ui/src/apps/device-group/view/pages/ReservedPage/ReservedPage.styles.ts
@@ -1,6 +1,6 @@
 import { makeStyles } from '@material-ui/styles';
 
-export const useStyles = makeStyles(() => ({
+export const useStyles = makeStyles({
     paper: {
         width: '100%',
         marginBottom: 20,
@@ -25,4 +25,4 @@ export const useStyles = makeStyles(() => ({
         justifyContent: 'end',
         marginTop: 20
     }
-}));
+});

--- a/apps/drec-ui/src/apps/device-group/view/pages/ReservedPage/ReservedPage.tsx
+++ b/apps/drec-ui/src/apps/device-group/view/pages/ReservedPage/ReservedPage.tsx
@@ -1,0 +1,59 @@
+import { FC } from 'react';
+import { CircularProgress, Paper, Typography, Grid, Button, Box } from '@material-ui/core';
+import { useStyles } from './ReservedPage.styles';
+import { useReservedPageEffects } from './ReservedPage.effects';
+import { GenericForm, TableComponent } from '@energyweb/origin-ui-core';
+
+export const ReservedPage: FC = () => {
+    const classes = useStyles();
+    const {
+        deviceGroups,
+        tableProps,
+        formData,
+        isLoading,
+        noReservedDeviceGroupsTitle,
+        onUnreserveHandler,
+        disableReserveButton
+    } = useReservedPageEffects();
+
+    if (isLoading) {
+        return <CircularProgress />;
+    }
+
+    return (
+        <Paper className={classes.paper}>
+            <Typography variant="h5">Reserved Device Groups</Typography>
+            <GenericForm
+                inputsVariant="filled"
+                twoColumns={true}
+                buttonWrapperProps={{
+                    justifyContent: 'flex-end'
+                }}
+                {...formData}
+            />
+            {deviceGroups?.length === 0 ? (
+                <Box style={{ width: '100%', margin: 20 }}>
+                    <Typography textAlign="center" variant="h6">
+                        {noReservedDeviceGroupsTitle}
+                    </Typography>
+                </Box>
+            ) : (
+                <>
+                    <Grid container className={classes.devicesWrapper} style={{ width: '100%' }}>
+                        <TableComponent {...tableProps} />
+                    </Grid>
+                    <div className={classes.buttonsWrapper}>
+                        <Button
+                            disabled={disableReserveButton}
+                            onClick={onUnreserveHandler}
+                            color="primary"
+                            variant="contained"
+                        >
+                            Unreserve
+                        </Button>
+                    </div>
+                </>
+            )}
+        </Paper>
+    );
+};

--- a/apps/drec-ui/src/apps/device-group/view/pages/ReservedPage/index.ts
+++ b/apps/drec-ui/src/apps/device-group/view/pages/ReservedPage/index.ts
@@ -1,0 +1,1 @@
+export * from './ReservedPage';

--- a/apps/drec-ui/src/apps/device-group/view/pages/UngroupedDevices/UngroupedDevicesPage.effects.ts
+++ b/apps/drec-ui/src/apps/device-group/view/pages/UngroupedDevices/UngroupedDevicesPage.effects.ts
@@ -40,7 +40,7 @@ export const useUngrouppedDevicesPageEffects = () => {
     };
 
     const handleChecked = (id: UngroupedDeviceDTO['id'], checked: boolean) => {
-        const selectedGroupedDevicesList = groupedDevicesList.map(
+        const selectedGroupedDevicesList = groupedDevicesList?.map(
             (groupedDeviceList: GroupedDevicesDTO) => {
                 const groupIndex = groupedDeviceList.devices.findIndex(
                     (selectableDevice) => selectableDevice.id === id
@@ -56,7 +56,7 @@ export const useUngrouppedDevicesPageEffects = () => {
 
     const onAutoGroupSelected = () => {
         const autoSelected: GroupedDevicesDTO[] = selectedDevicesList
-            .map((selectedGroup: GroupedDevicesDTO) => {
+            ?.map((selectedGroup: GroupedDevicesDTO) => {
                 const selectedDevices = selectedGroup?.devices?.filter(
                     (device: UngroupedDeviceDTO) => device.selected === true
                 );

--- a/apps/drec-ui/src/apps/device-group/view/pages/UnreservedPage/UnreservedPage.effects.ts
+++ b/apps/drec-ui/src/apps/device-group/view/pages/UnreservedPage/UnreservedPage.effects.ts
@@ -9,29 +9,31 @@ import { useAllDeviceFuelTypes, useUnreservedDeviceGroups } from '../../../data'
 import { useEffect, useState } from 'react';
 import { SelectableDeviceGroupDTO } from '@energyweb/origin-drec-api-client';
 
+const initialFormValues: UnreservedFormFormValues = {
+    country: [],
+    fuelCode: [],
+    installationConfiguration: '',
+    offTaker: '',
+    sector: '',
+    standardCompliance: '',
+    gridInterconnection: '',
+    commissioningDateRange: '',
+    capacityRange: ''
+};
+
 export const useUnreservedPageEffects = () => {
-    const initialFormValues: UnreservedFormFormValues = {
-        country: [],
-        fuelCode: [],
-        installationConfiguration: '',
-        offTaker: '',
-        sector: '',
-        standardCompliance: '',
-        gridInterconnection: '',
-        commissioningDateRange: '',
-        capacityRange: ''
-    };
     const [filterUnreserved, setFilterUnreserved] = useState(initialFormValues);
-    const { deviceGroups, isLoading: IsLoadingDeviceGroups } =
+    const { deviceGroups, isLoading: IsDeviceGroupsMutating } =
         useUnreservedDeviceGroups(filterUnreserved);
     const [selectedDeviceGroupList, setSelectedDeviceGroupList] = useState(deviceGroups);
     const dispatchModals = useDeviceGroupModalsDispatch();
 
     const { allTypes, isLoading: isDeviceTypesLoading } = useAllDeviceFuelTypes();
 
-    const { fields, initialValues, validationSchema, buttonText } = useDeviceGroupsFilterFormLogic(
+    const formLogic = useDeviceGroupsFilterFormLogic(
         filterUnreserved,
-        allTypes
+        allTypes,
+        IsDeviceGroupsMutating
     );
 
     const handleChecked = (id: SelectableDeviceGroupDTO['id'], checked: boolean) => {
@@ -46,7 +48,7 @@ export const useUnreservedPageEffects = () => {
     const tableProps = useSelectableDeviceGroupsTableLogic(
         deviceGroups,
         handleChecked,
-        IsLoadingDeviceGroups,
+        IsDeviceGroupsMutating,
         allTypes
     );
 
@@ -57,12 +59,9 @@ export const useUnreservedPageEffects = () => {
     const submitHandler = (values: UnreservedFormFormValues) => {
         setFilterUnreserved(values);
     };
-    const isLoading = IsLoadingDeviceGroups || isDeviceTypesLoading;
+    const isLoading = isDeviceTypesLoading;
     const formData: GenericFormProps<UnreservedFormFormValues> = {
-        fields,
-        initialValues,
-        validationSchema,
-        buttonText,
+        ...formLogic,
         submitHandler
     };
 

--- a/apps/drec-ui/src/apps/device-group/view/pages/UnreservedPage/UnreservedPage.styles.ts
+++ b/apps/drec-ui/src/apps/device-group/view/pages/UnreservedPage/UnreservedPage.styles.ts
@@ -1,6 +1,6 @@
 import { makeStyles } from '@material-ui/styles';
 
-export const useStyles = makeStyles(() => ({
+export const useStyles = makeStyles({
     wrapper: {
         width: '100%',
         display: 'flex',
@@ -33,4 +33,4 @@ export const useStyles = makeStyles(() => ({
         justifyContent: 'end',
         marginTop: 20
     }
-}));
+});

--- a/apps/drec-ui/src/apps/device-group/view/pages/UnreservedPage/UnreservedPage.styles.ts
+++ b/apps/drec-ui/src/apps/device-group/view/pages/UnreservedPage/UnreservedPage.styles.ts
@@ -2,7 +2,10 @@ import { makeStyles } from '@material-ui/styles';
 
 export const useStyles = makeStyles(() => ({
     wrapper: {
+        width: '100%',
         display: 'flex',
+        padding: '20px',
+        alignItems: 'center',
         flexDirection: 'column',
         gap: 20
     },

--- a/apps/drec-ui/src/apps/device-group/view/pages/index.ts
+++ b/apps/drec-ui/src/apps/device-group/view/pages/index.ts
@@ -3,3 +3,4 @@ export * from './AllDeviceGroupsPage';
 export * from './DetailViewGroupPage';
 export * from './UngroupedDevices';
 export * from './UnreservedPage';
+export * from './ReservedPage';

--- a/apps/drec-ui/src/main/AppContainer/AppContainer.effects.tsx
+++ b/apps/drec-ui/src/main/AppContainer/AppContainer.effects.tsx
@@ -28,7 +28,6 @@ export const useAppContainerEffects = () => {
     const {
         isOrganizationTabActive,
         isCertificateTabActive,
-        isDeviceTabActive,
         isDeviceGroupTabActive,
         isAccountTabActive,
         isAdminTabAcive
@@ -100,7 +99,8 @@ export const useAppContainerEffects = () => {
         showAllDeviceGroups: true,
         showMyDeviceGroups: userIsActive && userHasOrg && userIsDeviceManagerOrAdmin,
         showUngroupedDevices: userIsActive && userHasOrg && userIsDeviceManagerOrAdmin,
-        showUnreserved: userIsActive && userIsBuyer
+        showUnreserved: userIsActive && userHasOrg && userIsBuyer,
+        showReserved: userIsActive && userHasOrg && userIsBuyer
     };
     const deviceGroupMenu = getDeviceGroupMenu({
         isOpen: isDeviceGroupTabActive,


### PR DESCRIPTION
As a buyer, I want to be able to unreserve a device group.

1. A page with a list of the buyer’s reserved device groups

2. Functionality to unreserve the group

3. Modal to make sure that user wants to unreserve the device group

4. Same filtering as for buyer’s unreserved device group page 