### PR TITLE
fix(drec-ui) fixed smart meter reads

### DIFF
--- a/apps/drec-ui/src/apps/device-group/logic/smartMeter/chart/useChartDataLogic.ts
+++ b/apps/drec-ui/src/apps/device-group/logic/smartMeter/chart/useChartDataLogic.ts
@@ -9,9 +9,11 @@ export const useChartDataLogic = ({
     endDate,
     window
 }: TUseChartDataLogicArgs) => {
-    const datasets = useGenerateChartDataset(reads);
-
     const { multiplier, format } = intervalData[window];
+
+    const dateFormat = 'YYYY-MM-DDTHH:mm';
+    const datasets = useGenerateChartDataset(reads, startDate, endDate, multiplier, dateFormat);
+
     const labels = useGenerateChartLabels({
         start: startDate,
         end: endDate,

--- a/apps/drec-ui/src/apps/device-group/logic/smartMeter/chart/useGenerateChartDataset.ts
+++ b/apps/drec-ui/src/apps/device-group/logic/smartMeter/chart/useGenerateChartDataset.ts
@@ -1,9 +1,27 @@
 import { AggregatedReadDTO } from '@energyweb/origin-drec-api-client';
 import { useTheme } from '@mui/material';
+import dayjs from 'dayjs';
+import { DayJsTimeMultiplier } from '../../../../../utils';
 
-export const useGenerateChartDataset = (reads: AggregatedReadDTO[]) => {
+export const useGenerateChartDataset = (
+    reads: AggregatedReadDTO[],
+    start: Date,
+    end: Date,
+    multiplier: DayJsTimeMultiplier,
+    format: string
+) => {
     const theme = useTheme();
-    const currentData = reads.map((read) => read.value);
+    const currentData: number[] = [];
+
+    for (let current = start; current < end; current = dayjs(current).add(1, multiplier).toDate()) {
+        const currentRead = reads.find((read) => {
+            return (
+                dayjs(current).format(format) >= dayjs.utc(read.start).format(format) &&
+                dayjs(current).format(format) < dayjs.utc(read.stop).format(format)
+            );
+        });
+        currentData.push(currentRead?.value || 0);
+    }
 
     return [
         {


### PR DESCRIPTION
There is an issue with aggregated meter reads.
When the number of reads retrieved from the backend is smaller than the number of labels, then the reads are added to the wrong labels.