### PR TITLE
feat(drec-api) handle name conflict on bulk upload

### DIFF
--- a/apps/drec-api/package.json
+++ b/apps/drec-api/package.json
@@ -89,7 +89,8 @@
     "typeorm": "0.2.31",
     "uuid": "8.3.2",
     "@nestjs/axios": "~0.0.3",
-    "form-data": "~4.0.0"
+    "form-data": "~4.0.0",
+    "nanoid": "~3.1.30"
   },
   "devDependencies": {
     "@nestjs/cli": "7.5.4",

--- a/apps/drec-ui/src/apps/device-group/data/autoSelectGroups.ts
+++ b/apps/drec-ui/src/apps/device-group/data/autoSelectGroups.ts
@@ -19,7 +19,7 @@ export const useAutoSelectedGroups = (
     const autoSelectGroupsHandler = () => {
         const data: AddGroupDTO[] = selected.map((groupedDevice: GroupedDevicesDTO) => ({
             name: groupedDevice.name,
-            deviceIds: groupedDevice.devices.map((device: UngroupedDeviceDTO) => device.id)
+            deviceIds: groupedDevice?.devices.map((device: UngroupedDeviceDTO) => device.id)
         }));
         mutate(
             { data },

--- a/apps/drec-ui/src/apps/device-group/view/containers/UngroupedDevicesContainer/UngroupedDevicesContainer.effects.tsx
+++ b/apps/drec-ui/src/apps/device-group/view/containers/UngroupedDevicesContainer/UngroupedDevicesContainer.effects.tsx
@@ -13,7 +13,7 @@ export const useUngroupedDevicesContainerEffects = (
 
     const { allTypes, isLoading } = useAllDeviceFuelTypes();
     const isDisabledCreateGroup: boolean =
-        groupedDevices.devices.filter((device: UngroupedDeviceDTO) => device.selected === true)
+        groupedDevices?.devices.filter((device: UngroupedDeviceDTO) => device.selected === true)
             .length === 0;
 
     const actions: TableActionData<UngroupedDeviceDTO['id']>[] = [
@@ -24,7 +24,7 @@ export const useUngroupedDevicesContainerEffects = (
         }
     ];
     const tableProps = useUngroupedDevicesTableLogic(
-        groupedDevices.devices,
+        groupedDevices?.devices,
         actions,
         handleChecked,
         isLoading,

--- a/apps/drec-ui/src/apps/device-group/view/pages/DetailViewGroupPage/DetailViewGroupPage.tsx
+++ b/apps/drec-ui/src/apps/device-group/view/pages/DetailViewGroupPage/DetailViewGroupPage.tsx
@@ -24,9 +24,9 @@ export const DetailViewGroupPage: FC = () => {
 
     return (
         <div className={classes.wrapper}>
-            <DevicesMap devices={deviceGroup.devices} itemProps={{ className: classes.map }} />
+            <DevicesMap devices={deviceGroup?.devices} itemProps={{ className: classes.map }} />
             <DeviceGroupLocationData {...locationProps} />
-            <DeviceGroupName name={deviceGroup.name} />
+            <DeviceGroupName name={deviceGroup?.name} />
             <DetailViewCard {...cardProps} />
             <TableComponent {...tableProps} />
             <SmartMeterBlock deviceGroup={deviceGroup} />

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -25662,7 +25662,7 @@ packages:
     dev: false
 
   file:projects/origin-drec-api.tgz_prettier@2.1.2:
-    resolution: {integrity: sha512-4gyoUoJVC2CtLe+Lup/QV/m0c6oHGNi6tM1u28IC/nS5BHw8gP7YMSHX2QXr6P4ursuLKzinTSn9e9Saa0HBvQ==, tarball: file:projects/origin-drec-api.tgz}
+    resolution: {integrity: sha512-zILLKtST2IHrqHwysvZSsLABRB0hHnwjz9je2rcytC2VODbnWAB8VkI9KXS89M6j8ZWjYadfwVfToDSEesStAA==, tarball: file:projects/origin-drec-api.tgz}
     id: file:projects/origin-drec-api.tgz
     name: '@rush-temp/origin-drec-api'
     version: 0.0.0
@@ -25730,6 +25730,7 @@ packages:
       luxon: 1.27.0
       mocha: 8.2.1
       multer: 1.4.2
+      nanoid: 3.1.30
       nodemailer: 6.7.1
       passport: 0.4.1
       passport-jwt: 4.0.0


### PR DESCRIPTION
Sometimes when doing bulk upload, there might be two device-groups in separate batches which will share the same properties and they will have the same auto-generated name (this will happen rarely).
The name cannot be passed as a property to the body so as a solution, if there is a name conflict, we will generate a random set of 3 chars at the end of the name.
