### PR TITLE
fix(drec-ui) added missing fixes

### DIFF
--- a/apps/drec-api/src/pods/device-group/device-group.controller.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.controller.ts
@@ -65,7 +65,7 @@ export class DeviceGroupController {
   async getUnreserved(
     @Query(ValidationPipe) filterDto: UnreservedDeviceGroupsFilterDTO,
   ): Promise<SelectableDeviceGroupDTO[]> {
-    return this.deviceGroupService.getReservedOrUnreserved(filterDto, false);
+    return this.deviceGroupService.getReservedOrUnreserved(filterDto);
   }
 
   @Get('/reserved')
@@ -79,7 +79,7 @@ export class DeviceGroupController {
     @UserDecorator() { id }: ILoggedInUser,
     @Query(ValidationPipe) filterDto: UnreservedDeviceGroupsFilterDTO,
   ): Promise<SelectableDeviceGroupDTO[]> {
-    return this.deviceGroupService.getReservedOrUnreserved(filterDto, true, id);
+    return this.deviceGroupService.getReservedOrUnreserved(filterDto, id);
   }
 
   @Get('/my')

--- a/apps/drec-api/src/pods/device-group/device-group.service.ts
+++ b/apps/drec-api/src/pods/device-group/device-group.service.ts
@@ -118,7 +118,6 @@ export class DeviceGroupService {
 
   async getReservedOrUnreserved(
     filterDto: UnreservedDeviceGroupsFilterDTO,
-    selected: boolean,
     buyerId?: number,
   ): Promise<SelectableDeviceGroupDTO[]> {
     const query = this.getUnreservedFilteredQuery(filterDto, buyerId);
@@ -135,7 +134,7 @@ export class DeviceGroupService {
             name: organization.name,
             blockchainAccountAddress: organization.blockchainAccountAddress,
           },
-          selected,
+          selected: false,
         };
       }),
     );

--- a/apps/drec-ui/src/apps/device-group/logic/table/useSelectableDeviceGroupsTableLogic.tsx
+++ b/apps/drec-ui/src/apps/device-group/logic/table/useSelectableDeviceGroupsTableLogic.tsx
@@ -2,6 +2,7 @@ import { CodeNameDTO, SelectableDeviceGroupDTO } from '@energyweb/origin-drec-ap
 import { TableActionData, TableComponentProps } from '@energyweb/origin-ui-core';
 import { Checkbox } from '@mui/material';
 import { getFuelNameFromCode } from '../../../../utils';
+import { Countries } from '@energyweb/utils-general';
 
 const prepareSelectableDeviceGroupsData = (
     group: SelectableDeviceGroupDTO,
@@ -10,7 +11,7 @@ const prepareSelectableDeviceGroupsData = (
     handleChecked: (id: SelectableDeviceGroupDTO['id'], checked: boolean) => void
 ) => ({
     id: group.id,
-    country: group.countryCode,
+    country: Countries.find((country) => country.code === group.countryCode)?.name,
     organization: group.organization.name,
     fuelCode: getFuelNameFromCode(group.fuelCode, allFuelTypes),
     capacityRange: group.capacityRange,

--- a/apps/drec-ui/src/apps/device-group/logic/table/useUngroupedDevicesTableLogic.tsx
+++ b/apps/drec-ui/src/apps/device-group/logic/table/useUngroupedDevicesTableLogic.tsx
@@ -2,6 +2,7 @@ import { CodeNameDTO, UngroupedDeviceDTO } from '@energyweb/origin-drec-api-clie
 import { TableActionData, TableComponentProps } from '@energyweb/origin-ui-core';
 import { Checkbox } from '@mui/material';
 import { getFuelNameFromCode } from '../../../../utils';
+import { Countries } from '@energyweb/utils-general';
 
 const prepareUngroupedDevicesData = (
     device: UngroupedDeviceDTO,
@@ -11,7 +12,7 @@ const prepareUngroupedDevicesData = (
 ) => ({
     id: device.id,
     projectName: device.projectName,
-    country: device.countryCode,
+    country: Countries.find((country) => country.code === device.countryCode)?.name,
     fuelCode: getFuelNameFromCode(device.fuelCode, allFuelTypes),
     installation: device.installationConfiguration,
     capacity: device.capacityRange,

--- a/apps/drec-ui/src/apps/device-group/view/pages/ReservedPage/ReservedPage.effects.tsx
+++ b/apps/drec-ui/src/apps/device-group/view/pages/ReservedPage/ReservedPage.effects.tsx
@@ -83,7 +83,7 @@ export const useReservedPageEffects = () => {
 
     const onUnreserveHandler = () => {
         const autoSelected: SelectableDeviceGroupDTO[] = selectedDeviceGroupList.filter(
-            (group: SelectableDeviceGroupDTO) => group.selected === false
+            (group: SelectableDeviceGroupDTO) => group.selected === true
         );
         dispatchModals({
             type: DeviceGroupModalsActionsEnum.UNRESERVE,
@@ -99,7 +99,7 @@ export const useReservedPageEffects = () => {
 
     const disableReserveButton =
         selectedDeviceGroupList?.filter(
-            (group: SelectableDeviceGroupDTO) => group.selected === false
+            (group: SelectableDeviceGroupDTO) => group.selected === true
         ).length === 0;
 
     return {

--- a/apps/drec-ui/src/apps/device-group/view/pages/ReservedPage/ReservedPage.tsx
+++ b/apps/drec-ui/src/apps/device-group/view/pages/ReservedPage/ReservedPage.tsx
@@ -3,6 +3,7 @@ import { CircularProgress, Paper, Typography, Grid, Button, Box } from '@mui/mat
 import { useStyles } from './ReservedPage.styles';
 import { useReservedPageEffects } from './ReservedPage.effects';
 import { GenericForm, TableComponent } from '@energyweb/origin-ui-core';
+import DeleteIcon from '@mui/icons-material/Delete';
 
 export const ReservedPage: FC = () => {
     const classes = useStyles();
@@ -44,6 +45,7 @@ export const ReservedPage: FC = () => {
                     </Grid>
                     <div className={classes.buttonsWrapper}>
                         <Button
+                            startIcon={<DeleteIcon />}
                             disabled={disableReserveButton}
                             onClick={onUnreserveHandler}
                             color="primary"

--- a/apps/drec-ui/src/apps/device-group/view/pages/UnreservedPage/UnreservedPage.tsx
+++ b/apps/drec-ui/src/apps/device-group/view/pages/UnreservedPage/UnreservedPage.tsx
@@ -4,6 +4,7 @@ import { useStyles } from './UnreservedPage.styles';
 import { useUnreservedPageEffects } from './UnreservedPage.effects';
 import { GenericForm, TableComponent } from '@energyweb/origin-ui-core';
 import { OperatorApprovalMessageCard } from '../../containers';
+import AddCircleIcon from '@mui/icons-material/AddCircle';
 
 export const UnreservedPage: FC = () => {
     const classes = useStyles();
@@ -51,6 +52,7 @@ export const UnreservedPage: FC = () => {
                         </Grid>
                         <div className={classes.buttonsWrapper}>
                             <Button
+                                startIcon={<AddCircleIcon />}
                                 disabled={disableReserveButton}
                                 onClick={onReserveHandler}
                                 color="primary"


### PR DESCRIPTION
- Country names are displayed in a code, it’d be more user friendly to have an entire country name. 
- When unreserving devices from a group, user has to unselect these devices and then click “Unreserve selected devices”, which is counter intuitive. 