### PR TITLE
Update README.md before archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ⚠️ IMPORTANT NOTE
 
-This is repository is **deprecated**.
+This repository is **deprecated**.
 Work on the D-REC platform is continued [here](https://github.com/d-rec/drec-origin).
 
 **Background:**

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+# ⚠️ IMPORTANT NOTE
+
+This is repository is **deprecated**.
+Work on the D-REC platform is continued [here](https://github.com/d-rec/drec-origin).
+
+**Background:**
+
+With the creation of the D-REC Initiative, a dedicated Github organisation was created <https://github.com/d-rec>.
+The D-REC platform was forked and development continued under the new organisation.
+
+**Further information:**
+
+- <https://drecs.org/>
+- <https://enaccess.org/materials/drec/>
+
+---
+
 <h1 align="center">
   <br>
   <a href="https://www.energyweb.org/"><img src="https://www.energyweb.org/wp-content/uploads/2019/04/logo-brand.png" alt="EnergyWeb" width="150"></a>


### PR DESCRIPTION
Development of the D-REC platform has continued in this repository: https://github.com/d-rec/drec-origin

Unfortunately, the energyweb repository still ranks a bit higher in Google. Updating the README here to point potential contributors to the right place.

As next steps after this PR has been merged, it would be great, if we could

- archive `energywebfoundation/drec-origin`
- ~detach `d-rec/drec-origin` from `energywebfoundation/drec-origin` (via Github support)~ Done already